### PR TITLE
Adding periodic rediscovery logic

### DIFF
--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -490,14 +490,6 @@ describe('Discovery', () => {
     do {
       existingTasks = await discovery.waitForDiscoveryTasks();
     } while (existingTasks > 0);
-
-    // For await (const task of taskManager.getTasks('asc', false, [
-    //   Discovery.name,
-    //   discovery.discoverVertexHandlerId,
-    // ])) {
-    //   console.log(task);
-    // }
-
     await discovery.waitForDiscoveryTasks(true);
 
     await taskManager.stopProcessing();

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -569,56 +569,8 @@ describe('Discovery', () => {
     do {
       existingTasks = await discovery.waitForDiscoveryTasks();
     } while (existingTasks > 0);
-    // Only the queued vertex should be processed
+    // All vertices should be reprocessed
     expect(processVertexMock).toHaveBeenCalledTimes(3);
-
-    await taskManager.stopProcessing();
-    await discovery.stop();
-    await discovery.destroy();
-  });
-
-  test('asd', async () => {
-    const discovery = await Discovery.createDiscovery({
-      db,
-      keyRing,
-      gestaltGraph,
-      identitiesManager,
-      nodeManager,
-      taskManager,
-      logger,
-    });
-    await taskManager.startProcessing();
-
-    // Attempt initial discovery
-    await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
-
-    // None should be re-discovered since they were processed after the threshold
-    await discovery.checkRediscovery(0);
-    // There should be 0 discovery tasks
-
-    let tasks: number = 0;
-    for await (const _ of taskManager.getTasks('asc', false, [
-      Discovery.name,
-      discovery.discoverVertexHandlerId,
-    ])) {
-      tasks++;
-    }
-    expect(tasks).toBe(0);
-
-    // All should be re-discovered
-    await discovery.checkRediscovery(Date.now());
-    tasks = 0;
-    for await (const _ of taskManager.getTasks('asc', false, [
-      Discovery.name,
-      discovery.discoverVertexHandlerId,
-    ])) {
-      tasks++;
-    }
-    expect(tasks).toBeGreaterThan(0);
 
     await taskManager.stopProcessing();
     await discovery.stop();

--- a/tests/gestalts/GestaltGraph.test.ts
+++ b/tests/gestalts/GestaltGraph.test.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
-import { fc, testProp } from '@fast-check/jest';
+import { fc, test } from '@fast-check/jest';
 import { AsyncIterableX as AsyncIterable } from 'ix/asynciterable';
 import GestaltGraph from '@/gestalts/GestaltGraph';
 import ACL from '@/acl/ACL';
@@ -267,9 +267,8 @@ describe('GestaltGraph', () => {
       gestaltsErrors.ErrorGestaltsGraphNotRunning,
     );
   });
-  testProp(
+  test.prop([gestaltNodeInfoComposedArb])(
     'getNode, setNode and unsetNode',
-    [gestaltNodeInfoComposedArb],
     async (gestaltNodeInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -291,9 +290,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([gestaltNodeInfoComposedArb])(
     'setNode updates node information',
-    [gestaltNodeInfoComposedArb],
     async (gestaltNodeInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -319,9 +317,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([linkNodeComposedArb])(
     'linkNodeAndNode and unlinkNodeAndNode',
-    [linkNodeComposedArb],
     async ({ gestaltNodeInfo1, gestaltNodeInfo2, linkNode }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -374,9 +371,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([gestaltIdentityInfoComposedArb])(
     'get, set and unset identity',
-    [gestaltIdentityInfoComposedArb],
     async (gestaltIdentityInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -405,9 +401,8 @@ describe('GestaltGraph', () => {
       }
     },
   );
-  testProp(
+  test.prop([gestaltIdentityInfoComposedArb])(
     'setIdentity updates identity info',
-    [gestaltIdentityInfoComposedArb],
     async (gestaltIdentityInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -446,9 +441,8 @@ describe('GestaltGraph', () => {
       }
     },
   );
-  testProp(
+  test.prop([linkIdentityComposedArb])(
     'linkNodeAndIdentity and unlinkNodeAndIdentity',
-    [linkIdentityComposedArb],
     async ({ gestaltNodeInfo, gestaltIdentityInfo, linkIdentity }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -502,9 +496,8 @@ describe('GestaltGraph', () => {
       }
     },
   );
-  testProp(
+  test.prop([gestaltInfoComposedArb])(
     'getVertex, setVertex and unsetVertex',
-    [gestaltInfoComposedArb],
     async (gestaltInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -525,9 +518,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([gestaltInfoComposedArb])(
     'setVertex updates vertex information',
-    [gestaltInfoComposedArb],
     async (gestaltInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -555,9 +547,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([linkVertexComposedArb])(
     'linkVertexAndVertex and unlinkVertexAndVertex',
-    [linkVertexComposedArb],
     async ({ gestaltVertexInfo1, gestaltVertexInfo2, gestaltLink }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -632,9 +623,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([gestaltNodeInfoComposedArb])(
     'getGestaltByNode',
-    [gestaltNodeInfoComposedArb],
     async (gestaltNodeInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -664,9 +654,8 @@ describe('GestaltGraph', () => {
       });
     },
   );
-  testProp(
+  test.prop([gestaltIdentityInfoComposedArb])(
     'getGestaltByIdentity',
-    [gestaltIdentityInfoComposedArb],
     async (gestaltIdentityInfo) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -699,7 +688,7 @@ describe('GestaltGraph', () => {
       });
     },
   );
-  testProp('getGestalt', [gestaltInfoComposedArb], async (gestaltInfo) => {
+  test.prop([gestaltInfoComposedArb])('getGestalt', async (gestaltInfo) => {
     const gestaltGraph = await GestaltGraph.createGestaltGraph({
       db,
       acl,
@@ -752,50 +741,48 @@ describe('GestaltGraph', () => {
         fail('invalid type');
     }
   });
-  testProp(
-    'getGestalts with nodes',
-    [fc.array(gestaltNodeInfoComposedArb, { minLength: 2, maxLength: 10 })],
-    async (gestaltNodeInfos) => {
-      const ids = new Set<string>();
-      for (const gestaltNodeInfo of gestaltNodeInfos) {
-        ids.add(nodesUtils.encodeNodeId(gestaltNodeInfo.nodeId));
-      }
-      fc.pre(ids.size === gestaltNodeInfos.length);
-      const gestaltGraph = await GestaltGraph.createGestaltGraph({
-        db,
-        acl,
-        logger,
-        fresh: true,
+  test.prop([
+    fc.array(gestaltNodeInfoComposedArb, { minLength: 2, maxLength: 10 }),
+  ])('getGestalts with nodes', async (gestaltNodeInfos) => {
+    const ids = new Set<string>();
+    for (const gestaltNodeInfo of gestaltNodeInfos) {
+      ids.add(nodesUtils.encodeNodeId(gestaltNodeInfo.nodeId));
+    }
+    fc.pre(ids.size === gestaltNodeInfos.length);
+    const gestaltGraph = await GestaltGraph.createGestaltGraph({
+      db,
+      acl,
+      logger,
+      fresh: true,
+    });
+    for (const gestaltNodeInfo of gestaltNodeInfos) {
+      await gestaltGraph.setNode(gestaltNodeInfo);
+    }
+    const gestalts = await AsyncIterable.as(
+      gestaltGraph.getGestalts(),
+    ).toArray();
+    expect(gestalts).toHaveLength(gestaltNodeInfos.length);
+    for (const gestalt of gestalts) {
+      const gestaltId = Object.keys(gestalt.nodes)[0];
+      const [, nodeId] = gestaltsUtils.decodeGestaltNodeId(gestaltId)!;
+      expect(gestalt).toMatchObject({
+        matrix: {
+          [gestaltId]: {},
+        },
+        nodes: {
+          [gestaltId]: { nodeId },
+        },
+        identities: {},
       });
-      for (const gestaltNodeInfo of gestaltNodeInfos) {
-        await gestaltGraph.setNode(gestaltNodeInfo);
-      }
-      const gestalts = await AsyncIterable.as(
-        gestaltGraph.getGestalts(),
-      ).toArray();
-      expect(gestalts).toHaveLength(gestaltNodeInfos.length);
-      for (const gestalt of gestalts) {
-        const gestaltId = Object.keys(gestalt.nodes)[0];
-        const [, nodeId] = gestaltsUtils.decodeGestaltNodeId(gestaltId)!;
-        expect(gestalt).toMatchObject({
-          matrix: {
-            [gestaltId]: {},
-          },
-          nodes: {
-            [gestaltId]: { nodeId },
-          },
-          identities: {},
-        });
-      }
-    },
-  );
-  testProp(
+    }
+  });
+  test.prop([
+    fc
+      .array(gestaltIdentityInfoComposedArb, { minLength: 2, maxLength: 10 })
+      .noShrink(),
+  ])(
     'getGestalts with identities',
-    [
-      fc
-        .array(gestaltIdentityInfoComposedArb, { minLength: 2, maxLength: 10 })
-        .noShrink(),
-    ],
+
     async (gestaltIdentityInfos) => {
       const ids = new Set<string>();
       for (const gestaltIdentityInfo of gestaltIdentityInfos) {
@@ -836,80 +823,77 @@ describe('GestaltGraph', () => {
       }
     },
   );
-  testProp(
-    'getGestalts with nodes and identities',
-    [fc.array(gestaltInfoComposedArb, { minLength: 2, maxLength: 10 })],
-    async (gestaltInfos) => {
-      const ids = new Set<string>();
-      for (const gestaltInfo of gestaltInfos) {
-        const [type, data] = gestaltInfo;
-        switch (type) {
-          case 'identity':
-            ids.add(data.providerId + data.identityId);
-            break;
-          case 'node':
-            ids.add(nodesUtils.encodeNodeId(data.nodeId));
-            break;
-          default:
-            break;
-        }
+  test.prop([
+    fc.array(gestaltInfoComposedArb, { minLength: 2, maxLength: 10 }),
+  ])('getGestalts with nodes and identities', async (gestaltInfos) => {
+    const ids = new Set<string>();
+    for (const gestaltInfo of gestaltInfos) {
+      const [type, data] = gestaltInfo;
+      switch (type) {
+        case 'identity':
+          ids.add(data.providerId + data.identityId);
+          break;
+        case 'node':
+          ids.add(nodesUtils.encodeNodeId(data.nodeId));
+          break;
+        default:
+          break;
       }
-      fc.pre(ids.size === gestaltInfos.length);
-      const gestaltGraph = await GestaltGraph.createGestaltGraph({
-        db,
-        acl,
-        logger,
-        fresh: true,
-      });
-      for (const gestaltinfo of gestaltInfos) {
-        await gestaltGraph.setVertex(gestaltinfo);
+    }
+    fc.pre(ids.size === gestaltInfos.length);
+    const gestaltGraph = await GestaltGraph.createGestaltGraph({
+      db,
+      acl,
+      logger,
+      fresh: true,
+    });
+    for (const gestaltinfo of gestaltInfos) {
+      await gestaltGraph.setVertex(gestaltinfo);
+    }
+    const gestalts = await AsyncIterable.as(
+      gestaltGraph.getGestalts(),
+    ).toArray();
+    expect(gestalts).toHaveLength(gestaltInfos.length);
+    for (const gestalt of gestalts) {
+      const gestaltId = Object.keys(gestalt.matrix)[0];
+      const [type, id] = gestaltsUtils.decodeGestaltId(gestaltId)!;
+      switch (type) {
+        case 'node':
+          {
+            expect(gestalt).toMatchObject({
+              matrix: {
+                [gestaltId]: {},
+              },
+              nodes: {
+                [gestaltId]: { nodeId: id },
+              },
+              identities: {},
+            });
+          }
+          break;
+        case 'identity':
+          {
+            expect(gestalt).toMatchObject({
+              matrix: {
+                [gestaltId]: {},
+              },
+              nodes: {},
+              identities: {
+                [gestaltId]: {
+                  providerId: id[0],
+                  identityId: id[1],
+                },
+              },
+            });
+          }
+          break;
+        default:
+          fail('invalid type');
       }
-      const gestalts = await AsyncIterable.as(
-        gestaltGraph.getGestalts(),
-      ).toArray();
-      expect(gestalts).toHaveLength(gestaltInfos.length);
-      for (const gestalt of gestalts) {
-        const gestaltId = Object.keys(gestalt.matrix)[0];
-        const [type, id] = gestaltsUtils.decodeGestaltId(gestaltId)!;
-        switch (type) {
-          case 'node':
-            {
-              expect(gestalt).toMatchObject({
-                matrix: {
-                  [gestaltId]: {},
-                },
-                nodes: {
-                  [gestaltId]: { nodeId: id },
-                },
-                identities: {},
-              });
-            }
-            break;
-          case 'identity':
-            {
-              expect(gestalt).toMatchObject({
-                matrix: {
-                  [gestaltId]: {},
-                },
-                nodes: {},
-                identities: {
-                  [gestaltId]: {
-                    providerId: id[0],
-                    identityId: id[1],
-                  },
-                },
-              });
-            }
-            break;
-          default:
-            fail('invalid type');
-        }
-      }
-    },
-  );
-  testProp(
+    }
+  });
+  test.prop([linkNodeComposedArb])(
     'getGestalt with node links',
-    [linkNodeComposedArb],
     async ({ gestaltNodeInfo1, gestaltNodeInfo2, linkNode }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -969,9 +953,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([linkIdentityComposedArb])(
     'getGestalt with identity links',
-    [linkIdentityComposedArb],
     async ({ gestaltNodeInfo, gestaltIdentityInfo, linkIdentity }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -1032,9 +1015,8 @@ describe('GestaltGraph', () => {
       await gestaltGraph.stop();
     },
   );
-  testProp(
+  test.prop([linkVertexComposedArb])(
     'getGestalt with node and identity links',
-    [linkVertexComposedArb],
     async ({ gestaltVertexInfo1, gestaltVertexInfo2, gestaltLink }) => {
       const gestaltGraph = await GestaltGraph.createGestaltGraph({
         db,
@@ -1364,38 +1346,33 @@ describe('GestaltGraph', () => {
         })
         .noShrink();
 
-    testProp(
-      'model',
-      [altCommandsArb],
-      async (cmds) => {
-        await acl.start({ fresh: true });
-        const gestaltGraph = await GestaltGraph.createGestaltGraph({
-          db,
-          acl,
-          logger,
-          fresh: true,
-        });
-        try {
-          const model: testsGestaltsUtils.GestaltGraphModel = {
-            matrix: {},
-            nodes: {},
-            identities: {},
-            permissions: {},
+    test.prop([altCommandsArb], { numRuns: 20 })('model', async (cmds) => {
+      await acl.start({ fresh: true });
+      const gestaltGraph = await GestaltGraph.createGestaltGraph({
+        db,
+        acl,
+        logger,
+        fresh: true,
+      });
+      try {
+        const model: testsGestaltsUtils.GestaltGraphModel = {
+          matrix: {},
+          nodes: {},
+          identities: {},
+          permissions: {},
+        };
+        const modelSetup = async () => {
+          return {
+            model,
+            real: gestaltGraph,
           };
-          const modelSetup = async () => {
-            return {
-              model,
-              real: gestaltGraph,
-            };
-          };
-          await fc.asyncModelRun(modelSetup, cmds);
-        } finally {
-          await gestaltGraph.stop();
-          await acl.stop();
-        }
-      },
-      { numRuns: 20 },
-    );
+        };
+        await fc.asyncModelRun(modelSetup, cmds);
+      } finally {
+        await gestaltGraph.stop();
+        await acl.stop();
+      }
+    });
   });
   test('Should only set the newest ClaimId', async () => {
     const gestaltGraph = await GestaltGraph.createGestaltGraph({


### PR DESCRIPTION
### Description

This PR addresses periodic rediscovery logic

### Issues Fixed

* Fixes #691 
* Fixes ENG-27

### Tasks

- [x] 1. When a vertex is process, reschedule it.
- [x] 2. When a vertex has been processed recently then skip.
- [x] 3. When a vertex fails we need to reschedule it.
- [x] 4. Track the number of fails for a job and just give up on it if it exceeds a threshold.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
