### PR TITLE
Claim Discovery Task Atomization to Apply Task Deadline Individually Across Each Claim Request

### DIFF
--- a/src/claims/payloads/claimLinkIdentity.ts
+++ b/src/claims/payloads/claimLinkIdentity.ts
@@ -1,5 +1,9 @@
 import type { Claim, SignedClaim } from '../types';
-import type { NodeIdEncoded, ProviderIdentityIdEncoded } from '../../ids/types';
+import type {
+  NodeIdEncoded,
+  ProviderIdentityClaimId,
+  ProviderIdentityIdEncoded,
+} from '../../ids/types';
 import * as ids from '../../ids';
 import * as claimsUtils from '../utils';
 import * as tokensUtils from '../../tokens/utils';
@@ -13,6 +17,7 @@ interface ClaimLinkIdentity extends Claim {
   typ: 'ClaimLinkIdentity';
   iss: NodeIdEncoded;
   sub: ProviderIdentityIdEncoded;
+  providerIdentityClaimId?: ProviderIdentityClaimId;
 }
 
 function assertClaimLinkIdentity(

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -177,6 +177,7 @@ class Discovery {
           undefined,
           undefined,
           gestaltsUtils.decodeGestaltId(parent ?? undefined),
+          true,
         );
         return;
       }
@@ -503,9 +504,9 @@ class Discovery {
       );
       return;
     }
-    const linkedVertexNodeId = node1Id.equals(nodeId) ? node2Id : node1Id;
+    const linkedNodeId = node1Id.equals(nodeId) ? node2Id : node1Id;
     const linkedVertexNodeInfo: GestaltNodeInfo = {
-      nodeId: linkedVertexNodeId,
+      nodeId: linkedNodeId,
     };
     await this.gestaltGraph.linkNodeAndNode(
       {
@@ -521,7 +522,7 @@ class Discovery {
     if (claimId == null) never();
     await this.gestaltGraph.setClaimIdNewest(nodeId, claimId);
     // Add this vertex to the queue if it hasn't already been visited
-    const linkedGestaltId: GestaltId = ['node', linkedVertexNodeId];
+    const linkedGestaltId: GestaltId = ['node', linkedNodeId];
     if (
       !(await this.processedTimeGreaterThan(
         linkedGestaltId,
@@ -745,6 +746,7 @@ class Discovery {
     delay?: number,
     lastProcessedCutoffTime?: number,
     parent?: GestaltId,
+    ignoreActive: boolean = false,
     tran?: DBTransaction,
   ) {
     if (tran == null) {
@@ -754,6 +756,7 @@ class Discovery {
           delay,
           lastProcessedCutoffTime,
           parent,
+          ignoreActive,
           tran,
         ),
       );
@@ -776,7 +779,7 @@ class Discovery {
       tran,
     )) {
       // Ignore active tasks
-      if (task.status === 'active') continue;
+      if (ignoreActive && task.status === 'active') continue;
       if (taskExisting == null) {
         taskExisting = task;
         continue;

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -646,17 +646,15 @@ class Discovery {
     );
     const isAborted = ctx.signal.aborted;
     lastProviderPaginationToken = lastProviderPaginationToken_;
-    const gestaltNodeIds: Array<GestaltId> = [];
-    // Link the identity with each node from its claims on the provider
     // Iterate over each of the claims, even if ctx has aborted
     for (const [claimId, claim] of Object.entries(identityClaims)) {
       // Claims on an identity provider will always be node -> identity
       // So just cast payload data as such
-      const linkedVertexNodeId = nodesUtils.decodeNodeId(claim.payload.iss);
-      if (linkedVertexNodeId == null) never();
+      const linkedNodeId = nodesUtils.decodeNodeId(claim.payload.iss);
+      if (linkedNodeId == null) never();
       // With this verified chain, we can link
       const linkedVertexNodeInfo = {
-        nodeId: linkedVertexNodeId,
+        nodeId: linkedNodeId,
       };
       await this.gestaltGraph.linkNodeAndIdentity(
         linkedVertexNodeInfo,
@@ -672,8 +670,8 @@ class Discovery {
           },
         },
       );
-    }
-    for (const gestaltNodeId of gestaltNodeIds) {
+      // Check and schedule node for processing
+      const gestaltNodeId: GestaltId = ['node', linkedNodeId];
       if (
         !(await this.processedTimeGreaterThan(
           gestaltNodeId,

--- a/src/gestalts/types.ts
+++ b/src/gestalts/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '../ids/types';
 import type { SignedClaim, SignedClaimJSON } from '../claims/types';
 import type { ClaimLinkIdentity, ClaimLinkNode } from '../claims/payloads';
+import type { ProviderPaginationToken } from '../identities/types';
 
 const gestaltActions = ['notify', 'scan', 'claim'] as const;
 
@@ -41,6 +42,11 @@ type GestaltIdentityInfo = {
   name?: string;
   email?: string;
   url?: string;
+  /**
+   * Used to determine the last pagination token to resume
+   * from when discovering the identity vertex
+   */
+  lastProviderPaginationToken?: ProviderPaginationToken;
   // The `undefined` is a hack to include the optional reserved properties
   [key: string]: JSONValue | undefined;
 };

--- a/src/identities/Provider.ts
+++ b/src/identities/Provider.ts
@@ -29,6 +29,14 @@ abstract class Provider {
    */
   public abstract readonly id: ProviderId;
 
+  /**
+   * Set to true if getClaimsPage method should be preferred instead claim iteration operations.
+   * This could be useful if the Provider subclass has a getClaimsPage implentation that is able to
+   * obtain both Claims and ClaimsIds with a single HTTP request. For example, if the Provider were to
+   * supply a GraphQL API, or if the webscraped page were to contain the contents of both.
+   */
+  public readonly preferGetClaimsPage: boolean = false;
+
   public getTokens: GetTokens;
   public getToken: GetToken;
   public putToken: PutToken;

--- a/src/identities/Provider.ts
+++ b/src/identities/Provider.ts
@@ -189,7 +189,7 @@ abstract class Provider {
   ): Promise<IdentitySignedClaim | undefined>;
 
   /**
-   * Stream pages of identity claimIds from an identity
+   * Stream a page of identity claimIds from an identity
    */
   public abstract getClaimIdsPage(
     authIdentityId: IdentityId,
@@ -226,7 +226,7 @@ abstract class Provider {
   }
 
   /**
-   * Stream identity claims from an identity
+   * Stream a page of identity claims from an identity
    */
   public async *getClaimsPage(
     authIdentityId: IdentityId,
@@ -254,7 +254,7 @@ abstract class Provider {
   }
 
   /**
-   * Stream pages of identity claims from an identity
+   * Stream identity claims from an identity
    */
   public async *getClaims(
     authIdentityId: IdentityId,

--- a/src/identities/Provider.ts
+++ b/src/identities/Provider.ts
@@ -228,14 +228,30 @@ abstract class Provider {
   /**
    * Stream identity claims from an identity
    */
-  public abstract getClaimsPage(
+  public async *getClaimsPage(
     authIdentityId: IdentityId,
     identityId: IdentityId,
     paginationToken?: ProviderPaginationToken,
   ): AsyncGenerator<{
     claim: IdentitySignedClaim;
     nextPaginationToken?: ProviderPaginationToken;
-  }>;
+  }> {
+    const iterator = this.getClaimIdsPage(
+      authIdentityId,
+      identityId,
+      paginationToken,
+    );
+    for await (const { claimId, nextPaginationToken } of iterator) {
+      const claim = await this.getClaim(authIdentityId, claimId);
+      if (claim == null) {
+        continue;
+      }
+      yield {
+        claim,
+        nextPaginationToken,
+      };
+    }
+  }
 
   /**
    * Stream pages of identity claims from an identity

--- a/src/identities/providers/github/GitHubProvider.ts
+++ b/src/identities/providers/github/GitHubProvider.ts
@@ -22,6 +22,7 @@ import * as utils from '../../../utils';
 class GitHubProvider extends Provider {
   public readonly id = 'github.com' as ProviderId;
   public readonly clientId: string;
+  public readonly preferGetClaimsPage: boolean = true;
 
   protected readonly apiUrl: string = 'https://api.github.com';
   protected readonly gistFilename: string = 'cryptolink.txt';

--- a/src/identities/providers/github/GitHubProvider.ts
+++ b/src/identities/providers/github/GitHubProvider.ts
@@ -520,7 +520,8 @@ class GitHubProvider extends Provider {
   }
 
   /**
-   * Gets all ProviderIdentityClaimIds from a given identity.
+   * Gets a page of ProviderIdentityClaimIds from a given identity
+   * sorted by latest.
    */
   public async *getClaimIdsPage(
     _authIdentityId: IdentityId,
@@ -562,7 +563,8 @@ class GitHubProvider extends Provider {
   }
 
   /**
-   * Gets all IdentitySignedClaims from a given identity.
+   * Gets all IdentitySignedClaims from a given identity
+   * sorted by latest.
    */
   public async *getClaimsPage(
     _authIdentityId: IdentityId,

--- a/src/identities/types.ts
+++ b/src/identities/types.ts
@@ -55,6 +55,12 @@ type ProviderAuthenticateRequest = {
   data: POJO;
 };
 
+/**
+ * Generic opaque string used to represent a pagination token
+ * when making requests using an identity Provider.
+ * Do not expect this string to have any particular meaning
+ * outside of the Provider subclass it is used for.
+ */
 type ProviderPaginationToken = Opaque<'ProviderPaginationToken', string>;
 
 export type {

--- a/src/identities/types.ts
+++ b/src/identities/types.ts
@@ -6,6 +6,7 @@ import type {
 } from '../ids/types';
 import type { SignedClaim } from '../claims/types';
 import type { ClaimLinkIdentity } from '../claims/payloads';
+import type { Opaque } from 'encryptedfs';
 
 /**
  * Identity data contains key details about the
@@ -54,12 +55,15 @@ type ProviderAuthenticateRequest = {
   data: POJO;
 };
 
+type ProviderPaginationToken = Opaque<'ProviderPaginationToken', string>;
+
 export type {
   IdentityData,
   IdentitySignedClaim,
   ProviderToken,
   ProviderTokens,
   ProviderAuthenticateRequest,
+  ProviderPaginationToken,
 };
 
 export type {

--- a/src/identities/types.ts
+++ b/src/identities/types.ts
@@ -1,4 +1,4 @@
-import type { POJO } from '../types';
+import type { POJO, Opaque } from '../types';
 import type {
   ProviderId,
   IdentityId,
@@ -6,7 +6,6 @@ import type {
 } from '../ids/types';
 import type { SignedClaim } from '../claims/types';
 import type { ClaimLinkIdentity } from '../claims/payloads';
-import type { Opaque } from 'encryptedfs';
 
 /**
  * Identity data contains key details about the

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -1,7 +1,7 @@
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { Host } from '@/network/types';
 import type { Key } from '@/keys/types';
-import type { NodeId } from '../../src/ids';
+import type { NodeId } from '@/ids';
 import type { AgentServerManifest } from '@/nodes/agent/handlers';
 import type { DiscoveryQueueInfo } from '@/discovery/types';
 import type { ClaimLinkIdentity } from '@/claims/payloads/claimLinkIdentity';
@@ -31,10 +31,10 @@ import * as nodesUtils from '@/nodes/utils';
 import * as discoveryErrors from '@/discovery/errors';
 import * as keysUtils from '@/keys/utils';
 import * as gestaltsUtils from '@/gestalts/utils';
+import { encodeProviderIdentityId } from '@/ids';
 import * as testNodesUtils from '../nodes/utils';
 import TestProvider from '../identities/TestProvider';
 import 'ix/add/asynciterable-operators/toarray';
-import { encodeProviderIdentityId } from '../../src/ids';
 import { createTLSConfig } from '../utils/tls';
 
 describe('Discovery', () => {
@@ -76,6 +76,12 @@ describe('Discovery', () => {
     NodeManager.prototype,
     'refreshBucket',
   );
+
+  async function waitForAllDiscoveryTasks(discovery: Discovery) {
+    do {
+      /* Do nothing */
+    } while ((await discovery.waitForDiscoveryTasks()) > 0);
+  }
 
   beforeEach(async () => {
     testProvider = new TestProvider();
@@ -290,10 +296,7 @@ describe('Discovery', () => {
     });
     await taskManager.startProcessing();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     const gestalts = await AsyncIterable.as(
       gestaltGraph.getGestalts(),
     ).toArray();
@@ -328,10 +331,7 @@ describe('Discovery', () => {
     });
     await taskManager.startProcessing();
     await discovery.queueDiscoveryByIdentity(testToken.providerId, identityId);
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     const gestalts = await AsyncIterable.as(
       gestaltGraph.getGestalts(),
     ).toArray();
@@ -366,10 +366,7 @@ describe('Discovery', () => {
     });
     await taskManager.startProcessing();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     const gestalts1 = await AsyncIterable.as(
       gestaltGraph.getGestalts(),
     ).toArray();
@@ -422,9 +419,7 @@ describe('Discovery', () => {
     // Note that eventually we would like to add in a system of revisiting
     // already discovered vertices, however for now we must do this manually.
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     const gestalts2 = await AsyncIterable.as(
       gestaltGraph.getGestalts(),
     ).toArray();
@@ -451,7 +446,7 @@ describe('Discovery', () => {
     await discovery.stop();
     await discovery.destroy();
   });
-  test('discovery persistence across restarts', async () => {
+  test('node discovery persistence across restarts', async () => {
     const discovery = await Discovery.createDiscovery({
       db,
       keyRing,
@@ -465,10 +460,7 @@ describe('Discovery', () => {
     await discovery.stop();
     await discovery.start();
     await taskManager.startProcessing();
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     const gestalts = await AsyncIterable.as(
       gestaltGraph.getGestalts(),
     ).toArray();
@@ -491,6 +483,93 @@ describe('Discovery', () => {
     await discovery.stop();
     await discovery.destroy();
   });
+  test('identity discovery persistence across restarts', async () => {
+    const discovery = await Discovery.createDiscovery({
+      db,
+      keyRing,
+      gestaltGraph,
+      identitiesManager,
+      nodeManager,
+      taskManager,
+      logger,
+    });
+    await taskManager.startProcessing();
+    const identityId2 = 'other-gestalt2' as IdentityId;
+    await nodeA.identitiesManager.putToken(testToken.providerId, identityId2, {
+      accessToken: 'ghi789',
+    });
+    testProvider.users[identityId2] = {};
+    for (let i = 0; i < testProvider.pageSize * 2; i++) {
+      const identityClaim = {
+        typ: 'ClaimLinkIdentity',
+        iss: nodesUtils.encodeNodeId(nodeA.keyRing.getNodeId()),
+        sub: encodeProviderIdentityId([testProvider.id, identityId2]),
+      };
+      await nodeA.sigchain.addClaim(
+        identityClaim,
+        undefined,
+        async (token: Token<ClaimLinkIdentity>) => {
+          // Publishing in the callback to avoid adding bad claims
+          const claim = token.toSigned();
+          const identitySignedClaim = await testProvider.publishClaim(
+            identityId2,
+            claim,
+          );
+          // Append the ProviderIdentityClaimId to the token
+          const payload: ClaimLinkIdentity = {
+            ...claim.payload,
+            providerIdentityClaimId: identitySignedClaim.id,
+          };
+          const newToken = Token.fromPayload(payload);
+          newToken.signWithPrivateKey(nodeA.keyRing.keyPair);
+          return newToken;
+        },
+      );
+    }
+
+    // Spy on getClaimsPage
+    let getClaimsPageMockCalls = 0;
+    const firstPageCompletedP = utils.promise();
+    const getClaimsPageMock = jest.spyOn(testProvider, 'getClaimsPage');
+    getClaimsPageMock.mockImplementation(async function* (
+      ...args: Parameters<typeof testProvider.getClaimsPage>
+    ) {
+      const result: ReturnType<typeof testProvider.getClaimsPage> =
+        TestProvider.prototype.getClaimsPage.call(testProvider, ...args);
+      for await (const claim of result) {
+        if (args[1] === identityId2) {
+          if (getClaimsPageMockCalls === testProvider.pageSize) {
+            // Trigger manual task stopping
+            firstPageCompletedP.resolveP();
+          }
+          getClaimsPageMockCalls++;
+        }
+        yield claim;
+      }
+    });
+    await discovery.queueDiscoveryByIdentity(testToken.providerId, identityId2);
+
+    await firstPageCompletedP.p;
+    await taskManager.stopProcessing();
+    await discovery.stop();
+    await discovery.start();
+    await taskManager.startProcessing();
+
+    await waitForAllDiscoveryTasks(discovery);
+    // This total claims gotten should be above 2 pages worth of claims, because there will be some overlap
+    expect(getClaimsPageMockCalls).toBeGreaterThanOrEqual(
+      2 * testProvider.pageSize,
+    );
+    // This total claims gotten should be below 3 pages worth of claims,
+    // because the overlap of claims should never exceed the no. of pages - 1
+    expect(getClaimsPageMockCalls).toBeLessThan(3 * testProvider.pageSize);
+
+    delete testProvider.users[identityId2];
+    getClaimsPageMock.mockReset();
+    await taskManager.stopProcessing();
+    await discovery.stop();
+    await discovery.destroy();
+  });
   test('processed vertices are queued for rediscovery', async () => {
     const discovery = await Discovery.createDiscovery({
       db,
@@ -504,10 +583,8 @@ describe('Discovery', () => {
     });
     await taskManager.startProcessing();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+
+    await waitForAllDiscoveryTasks(discovery);
     await discovery.waitForDiscoveryTasks(true);
 
     await taskManager.stopProcessing();
@@ -531,18 +608,14 @@ describe('Discovery', () => {
 
     // Attempt initial discovery
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+
+    await waitForAllDiscoveryTasks(discovery);
     // All the vertices should be processed
     expect(processVertexMock).toHaveBeenCalledTimes(3);
     // 2nd attempt at discovery
     processVertexMock.mockReset();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     // Only the queued vertex should be processed
     expect(processVertexMock).toHaveBeenCalledTimes(1);
 
@@ -567,18 +640,14 @@ describe('Discovery', () => {
 
     // Attempt initial discovery
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+
+    await waitForAllDiscoveryTasks(discovery);
     // All the vertices should be processed
     expect(processVertexMock).toHaveBeenCalledTimes(3);
     // 2nd attempt at discovery
     processVertexMock.mockClear();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId(), Date.now());
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
     // All vertices should be reprocessed
     expect(processVertexMock).toHaveBeenCalledTimes(3);
 
@@ -605,10 +674,7 @@ describe('Discovery', () => {
     });
     await taskManager.startProcessing();
     await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
-    let existingTasks: number = 0;
-    do {
-      existingTasks = await discovery.waitForDiscoveryTasks();
-    } while (existingTasks > 0);
+    await waitForAllDiscoveryTasks(discovery);
 
     // Just checking basic functionality of queued and processed
     expect(eventMap.get(discoveryEvents.EventDiscoveryVertexQueued.name)).toBe(

--- a/tests/identities/TestProvider.ts
+++ b/tests/identities/TestProvider.ts
@@ -20,14 +20,13 @@ import * as tokenUtils from '@/tokens/utils';
 
 class TestProvider extends Provider {
   public readonly id: ProviderId;
+  public readonly pageSize = 10;
 
   public linkIdCounter: number = 0;
   public users: Record<IdentityId, POJO>;
   public links: Record<ProviderIdentityClaimId, string>;
   protected userLinks: Record<IdentityId, Array<ProviderIdentityClaimId>>;
   protected userTokens: Record<string, IdentityId>;
-
-  protected readonly pageSize = 10;
 
   public constructor(providerId: ProviderId = 'test-provider' as ProviderId) {
     super();


### PR DESCRIPTION
### Description

The goal of this PR is to refactor the `Discovery` domain so that `discoverVertexHandler` does not timeout upon making multiple GET requests for claims on the identity provider.

This will fix the issue listed as currently, what is failing the discovery of multiple claims is purely the fact that `Discovery.verifyIdentityClaims` is not an atomic operation. The method will only return once all ClaimIds and their associated Claims have been retrieved from the identity provider.

In the case of GitHub, where `n = number of claims`, the requests made for the discovery of a given identity will be `ceiling(n / 10) + n`. The reason for the `ceiling(n / 10)` requests is that GitHub will only show 10 Gists per page, meaning that we have to paginate to get all ClaimIds.

Given that the amount of requests, and therefore amount of time taken scales linearly, that is why `discoverVertexHandler` times out when processing more than 1 Claim.

#### Task Aggregation

Upon realizing debugging many, many, many tasks might be a pain, I've realized the most painless solution.

Instead of scheduling a task for each request made, we can simply refresh the ctx to emulate this behaviour. Refreshing a ctx will not reset the timer if the timer has already hit the deadline, so it makes it very easy to emulate this behaviour. Furthermore, since the task is rescheduled when lazily cancelled by the task manager stopping, we can just paramaritise our progress before the task manager shuts down.

From here on out, please keep this in mind when I talk about creating new tasks, as I am now doing this instead.

#### Claim Pagination

Given that the time taken to paginate across a gist search to find all ClaimIds is `ceiling(n / 10)`, we could run into a timeout on this task. This would happen with the current implementation:

![Untitled-2023-10-23-0424 excalidraw](https://github.com/MatrixAI/Polykey/assets/50583248/7d19b961-3718-4dd0-aba6-c64ea1fb8008)

In order to apply our timeout deadline to each request individually, we can instead have the task that processes the first page schedule a task to process the second page once it is done:

![Untitled-2023-10-23-0424 excalidraw](https://github.com/MatrixAI/Polykey/assets/50583248/653c5eb6-e81c-4e91-b38e-2e000664a6f4)

In order to do this we need a way to paginate through each page of Claims that is:

1. the least common denominator of all APIs
2. is serializable

The way we can do this is by returning a generic `Opaque` `String` that represents the `PaginationToken` to to be handed to the next task to execute their query. This type will have no meaning other than being what should be provided to the next function to get the next page.

#### Claim Requests

Each task to process a page can represent a pipeline to get all of the contents of the claims on that particular page. The directed graph in the order of which tasks are scheduled can be represented as so:

![Untitled-2023-10-23-0424 excalidraw](https://github.com/MatrixAI/Polykey/assets/50583248/22070b7d-3661-4bb8-b979-c95286a20954)

This way, we can streamline the meaning of `Discovery.discoverVertexTimeoutTime` to be the timeout time of each request in the Discovery task pipelines. By binding the timeout time with a specific expectation, we can expect less unexpected errors such as that found in the issue. 

#### Identities `Provider` Abstract Class Interface

Because we now have to account for __pagination__  + __getting claim ids to schedule tasks for requesting each claim__, we need to have a `getClaimIds` async generator method on `Provider` interface.

We will also need to add paginated versions of the `getClaims` and `getClaimIds` methods that will also return a paginationToken. The reason for this, is so that the task to process each request triggered by the method call to a paginated `get...` method, as well as resume if the task were stopped. This will be a bit messy as we cannot follow our existing pagination conventions, considering that there different providers will use different pagination methods. GitHub will use page index, but Twitter will use tokens and timestamps.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes https://github.com/MatrixAI/Polykey-CLI/issues/181
* Fixes https://github.com/MatrixAI/Polykey/issues/723

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Update `Identities.Provider` abstract class to include paginated API options
- [x] 2. Change `Discovery.verifyIdentityClaims` so that we can schedule a task for requesting and processing each claim separately.
- [x] 3. Implementing progress saving to the `Discovery` handler
- [x] 4. Implement flag that will prefer usage of `getClaimPages` directly in the case where data can be aggregated more efficiently

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
