### PR TITLE
Fixing intermittent failures due to `js-quic` stream errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.2",
         "@matrixai/mdns": "^1.2.6",
-        "@matrixai/quic": "^1.2.6",
+        "@matrixai/quic": "^1.2.7",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.5.1",
         "@matrixai/timer": "^1.1.3",
@@ -1560,9 +1560,9 @@
       "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.2.6.tgz",
-      "integrity": "sha512-qWVVGRqQla33BLrt4aHJAlZzUCQhQmrZr6+0zLbk2NTf7/RmAJaIdtCP7WxMzLe2uw3D+VB946Bzkwlc+pwk9g==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.2.7.tgz",
+      "integrity": "sha512-e2RH/xbW4XzoaAKLFgSYmMFW164gVbAFytTYnWtUxS2kY+eJtErFHpvYS1aWfV6LUV2mJLmI7yBfE4IuDUInew==",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.10.0",
@@ -1576,17 +1576,17 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.2.6",
-        "@matrixai/quic-darwin-universal": "1.2.6",
-        "@matrixai/quic-darwin-x64": "1.2.6",
-        "@matrixai/quic-linux-x64": "1.2.6",
-        "@matrixai/quic-win32-x64": "1.2.6"
+        "@matrixai/quic-darwin-arm64": "1.2.7",
+        "@matrixai/quic-darwin-universal": "1.2.7",
+        "@matrixai/quic-darwin-x64": "1.2.7",
+        "@matrixai/quic-linux-x64": "1.2.7",
+        "@matrixai/quic-win32-x64": "1.2.7"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.6.tgz",
-      "integrity": "sha512-khQLgI1DOW2gEnB9KiYGPZtt4PhD7UXj+oV3xyzyrRWcFWHDvhq/N5S7vciUv5R4hlED7u/6TMNigPYOhrkjdw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-X+FmTFUW2TjasNi87AxQfAI+2b2q1BYtJYu8+qqQVaC8htOf3jbgInJ1Msj6thzecQa6v0xgFZ8Oh2Oz9/Kjfg==",
       "cpu": [
         "arm64"
       ],
@@ -1596,9 +1596,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-universal": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-universal/-/quic-darwin-universal-1.2.6.tgz",
-      "integrity": "sha512-bR/JkJUV7jm+Oo81Jixxl71JrwOIXKODldTAXXxEURBtSEtnsJAroDVfij8t7w7cSunydmlPosUNLMTm4k39RQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-universal/-/quic-darwin-universal-1.2.7.tgz",
+      "integrity": "sha512-ljSXCJ7XjBtXI3HzHE9XAMT3na7nruumzS5Si1Y7JpNxWNDNoTa87zwzWEZ4Ws/2dhpE6Ae6epVJ7Xguib9mOw==",
       "cpu": [
         "x64",
         "arm64"
@@ -1609,9 +1609,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.6.tgz",
-      "integrity": "sha512-xu0DlfVI8uv0SWc0CX9ALbBxwqX4SRwhkfFbl6BzMmTUAQ4yw17G7AK6NXDkZ3hJ4j/CF2mAMXoJNvzC1HK+/A==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-V2gJPkZJOjo55D5VHP9iVIuQdHoGyMX9Xa7P3ur8+gQDSyBklnvgHbp47c3LNEzo8/NcqxRwADp3yzL3Ym94aA==",
       "cpu": [
         "x64"
       ],
@@ -1621,9 +1621,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.6.tgz",
-      "integrity": "sha512-POE3MTjauEf+bUBySdRupUPuAdG2xKrulMzcY+dmDTlqeqoc7EUHz4aXB++Pv9wqDzCn55Hx54r5GCRKA2o7rg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.7.tgz",
+      "integrity": "sha512-uRCqCdpQQsHSuYZHfnO+AjWk1fVLZrpJB4tp9bxf6ZA5aPNWSEsbd3Di7ZTeYzw0ONgQBbEI9DW4JjS+WcUIFQ==",
       "cpu": [
         "x64"
       ],
@@ -1633,9 +1633,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.6.tgz",
-      "integrity": "sha512-nnMXS2LcGa+8xopLkv5968QYwKwskSZypsedO6xaGIf60BLTVw3HqDsVH+xzdQWuZJuyIJ2ehlHiL9PzycVnzQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.7.tgz",
+      "integrity": "sha512-Lzc7JcRyFxXcs4lHXqGFkHZJCs3iBJPeKpuOr3ByC8c3n1KW+kuOeoDH3undbNBTPrZ8/2v5V3fRWPblXk8ZTQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@matrixai/id": "^3.3.6",
     "@matrixai/logger": "^3.1.2",
     "@matrixai/mdns": "^1.2.6",
-    "@matrixai/quic": "^1.2.6",
+    "@matrixai/quic": "^1.2.7",
     "@matrixai/resources": "^1.1.5",
     "@matrixai/rpc": "^0.5.1",
     "@matrixai/timer": "^1.1.3",

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -188,6 +188,13 @@ class ErrorNodeConnectionManagerRequestRateExceeded<
   exitCode = sysexits.TEMPFAIL;
 }
 
+class ErrorNodeConnectionManagerSignalFailed<
+  T,
+> extends ErrorNodeConnectionManager<T> {
+  static description = 'Failed to signal hole punching';
+  exitCode = sysexits.TEMPFAIL;
+}
+
 class ErrorNodePingFailed<T> extends ErrorNodes<T> {
   static description =
     'Failed to ping the node when attempting to authenticate';
@@ -240,6 +247,7 @@ export {
   ErrorNodeConnectionManagerMultiConnectionFailed,
   ErrorNodeConnectionManagerConnectionNotFound,
   ErrorNodeConnectionManagerRequestRateExceeded,
+  ErrorNodeConnectionManagerSignalFailed,
   ErrorNodePingFailed,
   ErrorNodePermissionDenied,
   ErrorNodeLookupNotFound,

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -803,6 +803,8 @@ class VaultInternal {
    *
    * ```
    */
+  // FIXME: if we have connection errors then we don't want to throw them into the `git.clone` or `git.pull`
+  //  To fix that the stream createation must happen BEFORE returning from `request` so that `request` itself will throw the error..
   protected async request(
     client: RPCClient<typeof agentClientManifest>,
     vaultNameOrId: VaultId | VaultName,

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -928,7 +928,6 @@ describe('VaultManager', () => {
         vaultsErrors.ErrorVaultsPermissionDenied,
       );
     });
-    // FIXME: Test has been disabled due to non-deterministic failures in CI/CD
     test(
       'can pull a cloned vault',
       async () => {


### PR DESCRIPTION
### Description

This PR addressed #722 

The main problem was during certain circumstances an error that should've been thrown through a stream was escaping the call stack and crashing the program. This was due to improper usage of throw within the stream handlers. This has been resolved within `js-quic`.

Note that the branch name doesn't describe the problem scope very well. It was created while I was still exploring what the actual issue was. While mainnet connections in tests could still happen, they shouldn't be causing this issue regardless. No amount of interacting with random network traffic should crash the program.

#461  was removed from this PR, it turns out to not actually be a requirement.

### Issues Fixed

* Fixes #722 
* Ref ENG-317

### Tasks

- [X] 1. find the problem causing intermittent errors.
- [X] 2. Apply the fix to `js-quic` and update the dependency version pulling in the fix
- [X] 3. Applied any other minor fixes

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
