### PR TITLE
Adding multiple path support when requesting audit events

### DIFF
--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -68,6 +68,9 @@ type AuditEventToAuditEventSerialized<T extends AuditEvent> = Omit<T, 'id'> & {
   id: AuditEventIdEncoded;
 };
 
+/**
+ * Equivalent to `Array<string>` but restricted to the available paths in `topicPaths`.
+ */
 type TopicPath = (typeof topicPaths)[number];
 
 type TopicSubPath<T = TopicPath> =
@@ -158,6 +161,9 @@ type AuditEventDiscoveryCheckRediscovery = AuditEventBase<
   typeof discoveryCheckRediscoveryTopicPath
 >;
 
+// @ts-ignore: recursive definition for defining a tree
+type TopicPathTreeNode = Record<string, TopicPathTreeNode>;
+
 // Metrics
 
 type MetricPath = (typeof metricPaths)[number];
@@ -213,6 +219,7 @@ export type {
   AuditEventDiscoveryVertexCulled,
   AuditEventDiscoveryVertexCancelled,
   AuditEventDiscoveryCheckRediscovery,
+  TopicPathTreeNode,
   // Metric
   MetricPath,
   MetricPathToAuditMetric,

--- a/src/audit/utils.ts
+++ b/src/audit/utils.ts
@@ -7,10 +7,12 @@ import type {
   AuditEventDiscoveryVertexCulled,
   AuditEventDiscoveryVertexCancelled,
   AuditEventDiscoveryCheckRediscovery,
+  TopicPathTreeNode,
 } from './types';
 import type * as nodesEvents from '../nodes/events';
 import type * as discoveryEvents from '../discovery/events';
 import type { AuditEventId } from '../ids';
+import type { TopicPath } from './types';
 import { IdInternal } from '@matrixai/id';
 import * as sortableIdUtils from '@matrixai/id/dist/IdSortable';
 import * as nodesUtils from '../nodes/utils';
@@ -187,6 +189,43 @@ const topicPaths = [
   discoveryCheckRediscoveryTopicPath,
 ] as const;
 
+/**
+ * Takes the list of `topicPaths` and converts it to a tree structure.
+ * This structure is much more efficient when checking if a path is a valid `TopicPath`.
+ */
+function generateTopicPathTree() {
+  const tree: TopicPathTreeNode = {};
+  for (const topicPath of topicPaths) {
+    let node: TopicPathTreeNode = tree;
+    for (const topicPathElement of topicPath) {
+      if (node[topicPathElement] == null) node[topicPathElement] = {};
+      node = node[topicPathElement];
+    }
+  }
+  return tree;
+}
+
+/**
+ * All the valid `topicPath`s condensed into a tree format.
+ * Used to quickly check if a path is valid.
+ */
+const topicPathTree = generateTopicPathTree();
+
+/**
+ * TypeGuard used to assert if a value is a `TopicPath`.
+ * Uses `topicPathTree` to quickly check if the path is valid.
+ */
+function isTopicPath(it: unknown): it is TopicPath {
+  if (!Array.isArray(it)) return false;
+  let node = topicPathTree;
+  for (const pathElement of it) {
+    if (typeof pathElement !== 'string') return false;
+    if (node[pathElement] == null) return false;
+    node = node[pathElement];
+  }
+  return true;
+}
+
 // Metrics
 
 // Nodes
@@ -211,6 +250,85 @@ const metricPaths = [
   nodeConnectionOutboundMetricPath,
 ] as const;
 
+/**
+ * Will take an array of dot path sorted paths and return the minimal list common paths.
+ * So sub-paths will be filtered out if we already contain a parent path E.G. `a.b` will be removed if we also include `a`.
+ * Duplicate paths will be removed, so `a` will be removed if two `a`'s exist.
+ */
+function filterSubPaths(paths: Array<Array<string>>): Array<Array<string>> {
+  let previous: string = '';
+  return paths
+    .map((v) => v.join('.'))
+    .sort()
+    .filter((value, index) => {
+      // Checking if the current value is included within the previous
+      if (index === 0 || !value.startsWith(previous)) {
+        previous = value;
+        return true;
+      }
+      return false;
+    }, {})
+    .map((v) => v.split('.'));
+}
+
+/**
+ * This takes N generators that yield data in a sorted order and combines their outputs in a fully sorted order.
+ * This will only work on pre-sorted outputs from the generator.
+ */
+async function* genSort<T>(
+  sortFn: (a: T, b: T) => number,
+  ...gens: Array<AsyncGenerator<T, void, void>>
+): AsyncGenerator<T, void, void> {
+  const heads: Array<{
+    value: T;
+    gen: AsyncGenerator<T, void, void>;
+    index: number;
+  }> = [];
+  // Seed the heads
+  let i = 0;
+  for (const gen of gens) {
+    const head = await gen.next();
+    if (!head.done) {
+      heads.push({
+        value: head.value,
+        gen,
+        index: i++,
+      });
+    }
+  }
+  if (heads.length === 0) return;
+
+  // Yield from heads until all iterators are done
+  let first = true;
+  let previous: T;
+  try {
+    while (true) {
+      // Sort them in order by the sortFn
+      heads.sort(({ value: a }, { value: b }) => sortFn(a, b));
+      // Yield the first in the order
+      const head = heads[0];
+      // Skip any duplicates
+      if (first || sortFn(previous!, head.value) !== 0) yield head.value;
+      first = false;
+      previous = head.value;
+      // Get the new head for that generator
+      const next = await head.gen.next();
+      // If the generator is done then we remove it from the heads, otherwise update the head value
+      if (next.done) {
+        heads.shift();
+      } else {
+        head.value = next.value;
+      }
+      // If the last head is done then we break
+      if (heads.length === 0) return;
+    }
+  } finally {
+    for (const { gen } of heads) {
+      await gen.return();
+    }
+  }
+}
+
 export {
   extractFromSeek,
   createAuditEventIdGenerator,
@@ -234,8 +352,12 @@ export {
   fromEventDiscoveryCheckRediscovery,
   nodeGraphTopicPath,
   topicPaths,
+  topicPathTree,
+  isTopicPath,
   nodeConnectionMetricPath,
   nodeConnectionInboundMetricPath,
   nodeConnectionOutboundMetricPath,
   metricPaths,
+  filterSubPaths,
+  genSort,
 };

--- a/src/client/callers/auditEventsGet.ts
+++ b/src/client/callers/auditEventsGet.ts
@@ -1,36 +1,8 @@
-import type { ReadableStream } from 'stream/web';
 import type { HandlerTypes } from '@matrixai/rpc';
-import type { ContextTimedInput } from '@matrixai/contexts';
-import type {
-  AuditEventToAuditEventSerialized,
-  TopicSubPath,
-  TopicSubPathToAuditEvent,
-} from '../../audit/types';
-import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
 import type AuditEventsGet from '../handlers/AuditEventsGet';
-import type { AuditEventIdEncoded } from '../../ids/types';
 import { ServerCaller } from '@matrixai/rpc';
 
 type CallerTypes = HandlerTypes<AuditEventsGet>;
-
-type AuditEventsGetTypeOverride = <T extends TopicSubPath>(
-  input: ClientRPCRequestParams<{
-    seek?: AuditEventIdEncoded | number;
-    seekEnd?: AuditEventIdEncoded | number;
-    order?: 'asc' | 'desc';
-    limit?: number;
-    awaitFutureEvents?: boolean;
-  }> & {
-    path: T;
-  },
-  ctx?: ContextTimedInput,
-) => Promise<
-  ReadableStream<
-    ClientRPCResponseResult<
-      AuditEventToAuditEventSerialized<TopicSubPathToAuditEvent<T>>
-    >
-  >
->;
 
 const auditEventsGet = new ServerCaller<
   CallerTypes['input'],
@@ -38,5 +10,3 @@ const auditEventsGet = new ServerCaller<
 >();
 
 export default auditEventsGet;
-
-export type { AuditEventsGetTypeOverride };

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -19,6 +19,8 @@ import AgentLockAll from './AgentLockAll';
 import AgentStatus from './AgentStatus';
 import AgentStop from './AgentStop';
 import AgentUnlock from './AgentUnlock';
+import AuditEventsGet from './AuditEventsGet';
+import AuditMetricGet from './AuditMetricGet';
 import GestaltsActionsGetByIdentity from './GestaltsActionsGetByIdentity';
 import GestaltsActionsGetByNode from './GestaltsActionsGetByNode';
 import GestaltsActionsSetByIdentity from './GestaltsActionsSetByIdentity';
@@ -89,8 +91,6 @@ import VaultsSecretsNewDir from './VaultsSecretsNewDir';
 import VaultsSecretsRename from './VaultsSecretsRename';
 import VaultsSecretsStat from './VaultsSecretsStat';
 import VaultsVersion from './VaultsVersion';
-import AuditEventsGet from './AuditEventsGet';
-import AuditMetricGet from './AuditMetricGet';
 
 /**
  * Server manifest factory.
@@ -205,6 +205,8 @@ export {
   AgentStatus,
   AgentStop,
   AgentUnlock,
+  AuditEventsGet,
+  AuditMetricGet,
   GestaltsActionsGetByIdentity,
   GestaltsActionsGetByNode,
   GestaltsActionsSetByIdentity,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -17,7 +17,6 @@ import type { CommitId, VaultAction, VaultName } from '../vaults/types';
 import type { CertificatePEM, JWKEncrypted, PublicKeyJWK } from '../keys/types';
 import type { Notification } from '../notifications/types';
 import type { ProviderToken } from '../identities/types';
-import type { AuditEventsGetTypeOverride } from './callers/auditEventsGet';
 import type { AuditMetricGetTypeOverride } from './callers/auditMetricGet';
 import type {
   NodeContact,
@@ -354,9 +353,8 @@ type OverrideRPClientType<T extends RPCClient<ClientManifest>> = Omit<
   'methods'
 > & {
   methods: {
-    auditEventsGet: AuditEventsGetTypeOverride;
     auditMetricGet: AuditMetricGetTypeOverride;
-  } & Omit<T['methods'], 'auditEventsGet' | 'auditMetricGet'>;
+  } & Omit<T['methods'], 'auditMetricGet'>;
 };
 
 export type {
@@ -420,6 +418,5 @@ export type {
   SecretStatMessage,
   SignatureMessage,
   OverrideRPClientType,
-  AuditEventsGetTypeOverride,
   AuditMetricGetTypeOverride,
 };

--- a/tests/audit/utils.test.ts
+++ b/tests/audit/utils.test.ts
@@ -1,0 +1,100 @@
+import fc from 'fast-check';
+import { test } from '@fast-check/jest';
+import * as auditUtils from '@/audit/utils';
+
+describe('Audit Utils', () => {
+  const sortFn = (a: number, b: number): number => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  };
+  const orderedNumberArrayArb = fc
+    .array(fc.integer({ min: 0, max: 100 }))
+    .map((array) => {
+      array.sort(sortFn);
+      return array;
+    });
+
+  /**
+   * Checks if the array is strictly ordered without duplicate numbers
+   */
+  function expectSortedArray(data: Array<number>) {
+    let previous: number | undefined;
+    for (const datum of data) {
+      if (previous == null) {
+        previous = datum;
+        continue;
+      }
+      if (!(previous <= datum)) {
+        throw Error(`${previous} was not less than ${datum} in ${data}`);
+      }
+      if (previous === datum) {
+        throw Error(`there should be no duplicate numbers`);
+      }
+    }
+  }
+
+  test('filterSubPaths', async () => {
+    // Out of theses only `a.b`, `e` and `f` are top level parents
+    const data = [
+      ['a', 'b', 'c'],
+      ['a', 'b', 'c'],
+      ['a', 'b', 'e'],
+      ['e', 'f'],
+      ['e', 'g'],
+      ['a', 'b'],
+      ['e'],
+      ['f'],
+      ['f'],
+    ];
+    const filtered = auditUtils.filterSubPaths(data).map((v) => v.join('.'));
+    expect(filtered).toHaveLength(3);
+    expect(filtered).toInclude('a.b');
+    expect(filtered).toInclude('e');
+    expect(filtered).toInclude('f');
+    expect(filtered).not.toInclude('a.b.c');
+    expect(filtered).not.toInclude('a.b.c');
+    expect(filtered).not.toInclude('a.b.e');
+    expect(filtered).not.toInclude('e.f');
+    expect(filtered).not.toInclude('e.g');
+  });
+  test.prop([fc.array(orderedNumberArrayArb).noShrink()])(
+    'can combine strictly ordered iterators',
+    async (generatorData) => {
+      async function* gen(
+        data: Array<number>,
+      ): AsyncGenerator<number, void, void> {
+        for (const datum of data) {
+          yield datum;
+        }
+      }
+
+      const expectedData: Set<number> = new Set();
+      for (const data of generatorData) {
+        for (const datum of data) {
+          expectedData.add(datum);
+        }
+      }
+      const expectedDataArray = [...expectedData];
+      expectedDataArray.sort(sortFn);
+
+      const gens = generatorData.map((data) => gen(data));
+      const sortedGen = auditUtils.genSort<number>(sortFn, ...gens);
+      const acc: Array<number> = [];
+      for await (const value of sortedGen) {
+        acc.push(value);
+      }
+      expectSortedArray(acc);
+      expect(acc).toMatchObject(expectedDataArray);
+    },
+  );
+  test('isAuditPath', async () => {
+    for (const topicPath of auditUtils.topicPaths) {
+      expect(auditUtils.isTopicPath(topicPath)).toBeTrue();
+      // Parent paths are also valid
+      expect(auditUtils.isTopicPath(topicPath.slice(0, 2))).toBeTrue();
+      expect(auditUtils.isTopicPath(topicPath.slice(0, 1))).toBeTrue();
+    }
+    expect(auditUtils.isTopicPath(['invalid', 'invalid'])).toBeFalse();
+  });
+});

--- a/tests/git/http.test.ts
+++ b/tests/git/http.test.ts
@@ -154,7 +154,7 @@ describe('Git Http', () => {
     'parsePackRequest handles random data',
     async (data) => {
       const bufferData = Buffer.from(data);
-      fc.pre(!/^[0-9a-f]{4}$/.test(bufferData.subarray(0, 4).toString()))
+      fc.pre(!/^[0-9a-f]{4}$/.test(bufferData.subarray(0, 4).toString()));
       await expect(gitHttp.parsePackRequest([bufferData])).rejects.toThrow(
         validationErrors.ErrorParse,
       );

--- a/tests/git/utils.test.ts
+++ b/tests/git/utils.test.ts
@@ -241,7 +241,7 @@ describe('Git utils', () => {
     'parseRequestLine handles bad data',
     async (randomData) => {
       const bufferData = Buffer.from(randomData);
-      fc.pre(!/^[0-9a-f]{4}$/.test(bufferData.subarray(0, 4).toString()))
+      fc.pre(!/^[0-9a-f]{4}$/.test(bufferData.subarray(0, 4).toString()));
       expect(() => gitUtils.parseRequestLine(bufferData)).toThrow(
         validationErrors.ErrorParse,
       );


### PR DESCRIPTION
### Description

This PR adds the `auditEventMultiPathGet` handler for getting audit events while specifying multiple event paths. The paths are specified in dot path format `a.b.c`. and filtered down to the minimum common paths in the list. Multiple iterators are created and combined when returning the stream.

### Issues Fixed

* No issues are directly fixed by this.
* Related: https://github.com/MatrixAI/Polykey-CLI/pull/178
* Ref ENG-303 

### Tasks

1. Create `auditEventMultiPathGet` handler for efficiently getting audit events while combining multiple audit paths.
2. Expand tests to check for properly sorted order in ascending and descending.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
