### PR TITLE
Handle failure to resolve seednodes

### DIFF
--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -25,6 +25,11 @@ class ErrorNodeManagerFindNodeFailed<T> extends ErrorNodeManager<T> {
   exitCode = sysexits.TEMPFAIL;
 }
 
+class ErrorNodeManagerResolveNodeFailed<T> extends ErrorNodeManager<T> {
+  static description = 'Failed to resolve node address using DNS';
+  exitCode = sysexits.TEMPFAIL;
+}
+
 class ErrorNodeManagerSyncNodeGraphFailed<T> extends ErrorNodeManager<T> {
   static description = 'Failed to enter the network with syncNodeGraph';
   exitCode = sysexits.TEMPFAIL;
@@ -218,6 +223,7 @@ export {
   ErrorNodeManagerNodeIdOwn,
   ErrorNodeManagerConnectionFailed,
   ErrorNodeManagerFindNodeFailed,
+  ErrorNodeManagerResolveNodeFailed,
   ErrorNodeManagerSyncNodeGraphFailed,
   ErrorNodeGraph,
   ErrorNodeGraphRunning,


### PR DESCRIPTION
### Description

This PR adds handling for failing to resolve seed nodes with DNS resolution.

### Issues Fixed

* Fixes #729 

### Tasks

- [x] 1. Add error reporting for failing to resolve seed nodes using DNS.
- ~2. We should use a fall-back in app DNS resolution if the normal method fails.~ - Pulled into a new issue at https://github.com/MatrixAI/Polykey-CLI/issues/202

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
