### PR TITLE
Adding social and permission level discovery

### DIFF
--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -42,8 +42,6 @@ import { never } from '../utils';
 import Token from '../tokens/Token';
 import { decodeClaimId } from '../ids';
 
-// TODO: add social and permission level discovery
-
 /**
  * This is the reason used to cancel duplicate tasks for vertices
  */

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -42,6 +42,8 @@ import { never } from '../utils';
 import Token from '../tokens/Token';
 import { decodeClaimId } from '../ids';
 
+// TODO: add social and permission level discovery
+
 /**
  * This is the reason used to cancel duplicate tasks for vertices
  */

--- a/src/gestalts/GestaltGraph.ts
+++ b/src/gestalts/GestaltGraph.ts
@@ -1104,7 +1104,12 @@ class GestaltGraph {
     switch (type) {
       case 'node': {
         if ((await tran.get([...this.dbNodesPath, gestaltKey], true)) == null) {
-          throw new gestaltsErrors.ErrorGestaltsGraphNodeIdMissing();
+          await this.setNode(
+            {
+              nodeId: id,
+            },
+            tran,
+          );
         }
         await this.acl.setNodeAction(id, action, tran);
         return;
@@ -1498,6 +1503,7 @@ class GestaltGraph {
     return gestalt;
   }
 
+  // FIXME: this returns only 1 node that is linked to an identity, It should really return all of them. Maybe convert to a generator?
   protected async getIdentityLinkedNodeId(
     providerIdentityId: ProviderIdentityId,
     tran: DBTransaction,

--- a/tests/client/handlers/gestalts.test.ts
+++ b/tests/client/handlers/gestalts.test.ts
@@ -1948,6 +1948,17 @@ describe('gestaltsGestaltTrustByNode', () => {
       notify: null,
     });
   });
+  test('trusts a node (not in gestalt graph)', async () => {
+    const request = {
+      nodeIdEncoded: nodeIdEncodedRemote,
+    };
+    await rpcClient.methods.gestaltsGestaltTrustByNode(request);
+    expect(
+      await gestaltGraph.getGestaltActions(['node', nodeIdRemote!]),
+    ).toEqual({
+      notify: null,
+    });
+  });
   test('trusts a node (new node)', async () => {
     const request = {
       nodeIdEncoded: nodeIdEncodedRemote,

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -468,9 +468,9 @@ describe('vaultsPermissionSet and vaultsPermissionUnset and vaultsPermissionGet'
       acl,
       logger,
     });
-    await gestaltGraph.setNode({
-      nodeId: nodeId,
-    });
+    // Await gestaltGraph.setNode({
+    //   nodeId: nodeId,
+    // });
     taskManager = await TaskManager.createTaskManager({
       db,
       logger,


### PR DESCRIPTION
### Description

This PR contains work for adding social and permission level discovery to the discovery domain.

### Issues Fixed

* Related #702 

### Tasks

- [ ] 1. Implement the ability to trust and give permissions to nodes without discovering them first.
- [ ] 2. Implement some way to list all social links for a provider. these need to include metadata such as existing claims and some useful information such as name, email and the like.
- [ ] 3. Implement an iterator for listing trust links
- [ ] 4. Implement an iterator for listing permission links. If permissions require trust then it might not be needed.
- [ ] 5. Discovery should trigger on start up and use existing know vertices as the starting point.
- [ ] 6. Implement priority queue when processing these social and permission links.

### Final checklist

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
