### PR TITLE
Identity Discovery Pagination Logic

### DIFF
--- a/tests/identities/TestProvider.ts
+++ b/tests/identities/TestProvider.ts
@@ -197,15 +197,23 @@ class TestProvider extends Provider {
         startIndex,
         this.pageSize + startIndex,
       ) ?? [];
+    // Check if the next page contains any claims and set the nextPaginationToken accordingly
+    // This is done to reveal pagination logic bugs in case a null pagination token is not considered as the exhaustion of all pages
+    let nextPageStartIndex: number | undefined = startIndex + this.pageSize;
+    const nextPageClaimIds =
+      this.userLinks[identityId].slice(
+        nextPageStartIndex,
+        this.pageSize + nextPageStartIndex,
+      ) ?? [];
+    if (nextPageClaimIds.length === 0) {
+      nextPageStartIndex = undefined;
+    }
     for (const [i, claimId] of claimIds.entries()) {
       yield {
         claimId,
-        nextPaginationToken:
-          i === claimIds.length - 1
-            ? ((
-                startIndex + this.pageSize
-              ).toString() as ProviderPaginationToken)
-            : undefined,
+        nextPaginationToken: (i === claimIds.length - 1
+          ? nextPageStartIndex?.toString()
+          : undefined) as ProviderPaginationToken | undefined,
       };
     }
   }


### PR DESCRIPTION
### Description
Fixes infinite loop on identity discovery pagination logic.

It turns out, because the pagination token is never set to null when it is meant to be, I end up looping on the last page of claims until the loop times out. The logic written here was also just originally too convoluted and made it hard to read. I've fixed this now.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes https://github.com/MatrixAI/Polykey-CLI/issues/203

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Fix infinite loop on identity discovery pagination logic

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
