### PR TITLE
adding `dnsServers` option to `polykey`

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -99,6 +99,7 @@ type PolykeyAgentOptions = {
     connectionHolePunchIntervalTime: number;
     rpcCallTimeoutTime: number;
     rpcParserBufferSize: number;
+    dnsServers: Array<string> | undefined;
   };
   mdns: {
     groups: Array<string>;
@@ -386,6 +387,7 @@ class PolykeyAgent {
           groups: optionsDefaulted.mdns.groups,
           port: optionsDefaulted.mdns.port,
         },
+        dnsServers: optionsDefaulted.nodes.dnsServers,
         logger: logger.getChild(NodeManager.name),
       });
       discovery = await Discovery.createDiscovery({

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -1,5 +1,5 @@
 import type { PromiseCancellable } from '@matrixai/async-cancellable';
-import type { ContextTimed } from '@matrixai/contexts';
+import type { ContextTimed, ContextTimedInput } from '@matrixai/contexts';
 import type { Address, Host, Hostname, Port } from './types';
 import type { NodeAddress } from '../nodes/types';
 import type { JSONValue } from '../types';
@@ -296,7 +296,7 @@ function isDNSError(e: { code: string }): boolean {
 function resolveHostname(
   hostname: Hostname,
   servers?: Array<string>,
-  ctx?: Partial<ContextTimed>,
+  ctx?: Partial<ContextTimedInput>,
 ): PromiseCancellable<Array<Host>> {
   const f = async (ctx: ContextTimed) => {
     const hosts: Array<Host> = [];
@@ -403,10 +403,14 @@ function resolvesZeroIP(ip: Host): Host {
  * It will also filter out any duplicates.
  * @param addresses
  * @param existingAddresses
+ * @param servers
+ * @param ctx
  */
 async function resolveHostnames(
   addresses: Array<NodeAddress>,
   existingAddresses: Set<string> = new Set(),
+  servers?: Array<string>,
+  ctx?: Partial<ContextTimedInput>,
 ): Promise<Array<[Host, Port]>> {
   const final: Array<[Host, Port]> = [];
   for (const [host, port] of addresses) {
@@ -416,7 +420,7 @@ async function resolveHostnames(
       existingAddresses.add(`${host}|${port}`);
       continue;
     }
-    const resolvedAddresses = await resolveHostname(host);
+    const resolvedAddresses = await resolveHostname(host, servers, ctx);
     for (const resolvedHost of resolvedAddresses) {
       const newAddress: [Host, Port] = [resolvedHost, port];
       if (


### PR DESCRIPTION
### Description

This PR adds a `dnsServers` option to the `PolykeyAgent`. This is passed into any DNS resolution attempts. If not provided then we default to the OS default setting. When provided the list is fully overridden, as such, an empty list will cause a failure to resolve anything.

This also passes in the `ctx` for cancellation when resolving.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey-CLI/issues/202
* REF ENG-338

### Tasks

- [X] 1. Add a `dnsServers` option to `PolykeyAgent`
- [X] 2. Pass dns server list down to any resolve calls.
- [x] 3. Add a logger info message for when we override DNS server list.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
