### PR TITLE
Implementing general-purpose file list handler

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -300,12 +300,11 @@ type VaultsLatestVersionMessage = {
 };
 
 // Secrets
-
-type SecretNameMessage = {
+type SecretPathMessage = {
   secretName: string;
 };
 
-type SecretIdentifierMessage = VaultIdentifierMessage & SecretNameMessage;
+type SecretIdentifierMessage = VaultIdentifierMessage & SecretPathMessage;
 
 // Contains binary content as a binary string 'toString('binary')'
 type ContentMessage = {
@@ -325,6 +324,11 @@ type SecretDirMessage = VaultIdentifierMessage & {
 
 type SecretRenameMessage = SecretIdentifierMessage & {
   newSecretName: string;
+};
+
+type SecretFilesMessage = {
+  path: string;
+  type: 'FILE' | 'DIRECTORY';
 };
 
 // Stat is the 'JSON.stringify version of the file stat
@@ -410,13 +414,14 @@ export type {
   VaultsScanMessage,
   VaultsVersionMessage,
   VaultsLatestVersionMessage,
-  SecretNameMessage,
+  SecretPathMessage,
   SecretIdentifierMessage,
   ContentMessage,
   SecretContentMessage,
   SecretMkdirMessage,
   SecretDirMessage,
   SecretRenameMessage,
+  SecretFilesMessage,
   SecretStatMessage,
   SignatureMessage,
   OverrideRPClientType,

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -1058,13 +1058,14 @@ class VaultManager {
       },
     );
     // Running the function with locking
+    const vaultThis = this;
     return yield* this.vaultLocks.withG(
       ...vaultLocks,
       async function* (): AsyncGenerator<T, Treturn, Tnext> {
         // Getting the vaults while locked
         const vaults = await Promise.all(
           vaultIds.map(async (vaultId) => {
-            return await this.getVault(vaultId, tran);
+            return await vaultThis.getVault(vaultId, tran);
           }),
         );
         return yield* g(...vaults);

--- a/src/vaults/errors.ts
+++ b/src/vaults/errors.ts
@@ -118,6 +118,16 @@ class ErrorSecretsIsDirectory<T> extends ErrorSecrets<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorSecretsIsSecret<T> extends ErrorSecrets<T> {
+  static description = 'Is a secret and not a directory';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorSecretsDirectoryUndefined<T> extends ErrorSecrets<T> {
+  static description = 'Directory does not exist';
+  exitCode = sysexits.USAGE;
+}
+
 export {
   ErrorVaults,
   ErrorVaultManagerRunning,
@@ -144,4 +154,6 @@ export {
   ErrorSecretsSecretUndefined,
   ErrorSecretsSecretDefined,
   ErrorSecretsIsDirectory,
+  ErrorSecretsIsSecret,
+  ErrorSecretsDirectoryUndefined,
 };


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
Currently, Polykey can only return a list of secrets within a vault. This PR aims to implement an RPC handler which creates a general-purpose function able to output data similar to the UNIX command `ls`.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to https://github.com/MatrixAI/Polykey-CLI/issues/245
* Relates to https://github.com/MatrixAI/Polykey-CLI/pull/255
* REF ENG-358

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Write RPC handler for UNIX `ls`
- [x] 2. Remove deprecated `list` command for secrets
- [x] 3. Write tests for `ls` handler
- ~~4. Write handler for streaming file contents~~ will be completed in `cat` command
- ~~5. Write tests for file streaming (`cat`) handler~~ will be completed in `cat` command

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
