### PR TITLE
Creating better file content streaming RPC methods

### DIFF
--- a/src/client/ClientService.ts
+++ b/src/client/ClientService.ts
@@ -99,6 +99,14 @@ class ClientService {
         keepAliveTimeoutTime,
       },
       logger: this.logger.getChild(WebSocketServer.name),
+      codeToReason: (type, code) => {
+        console.log(code);
+        return new Error(`webserver: ${type}: ${code}`);
+      },
+      reasonToCode: (_, reason) => {
+        console.error('webserver:', reason);
+        return 0;
+      }
     });
   }
 

--- a/src/client/callers/vaultsSecretsEdit.ts
+++ b/src/client/callers/vaultsSecretsEdit.ts
@@ -1,12 +1,5 @@
-import type { HandlerTypes } from '@matrixai/rpc';
-import type VaultsSecretsEdit from '../handlers/VaultsSecretsEdit';
-import { UnaryCaller } from '@matrixai/rpc';
+import { RawCaller } from '@matrixai/rpc';
 
-type CallerTypes = HandlerTypes<VaultsSecretsEdit>;
-
-const vaultsSecretsEdit = new UnaryCaller<
-  CallerTypes['input'],
-  CallerTypes['output']
->();
+const vaultsSecretsEdit = new RawCaller();
 
 export default vaultsSecretsEdit;

--- a/src/client/callers/vaultsSecretsGet.ts
+++ b/src/client/callers/vaultsSecretsGet.ts
@@ -1,12 +1,5 @@
-import type { HandlerTypes } from '@matrixai/rpc';
-import type VaultsSecretsGet from '../handlers/VaultsSecretsGet';
-import { UnaryCaller } from '@matrixai/rpc';
+import { RawCaller } from '@matrixai/rpc';
 
-type CallerTypes = HandlerTypes<VaultsSecretsGet>;
-
-const vaultsSecretsGet = new UnaryCaller<
-  CallerTypes['input'],
-  CallerTypes['output']
->();
+const vaultsSecretsGet = new RawCaller();
 
 export default vaultsSecretsGet;

--- a/src/client/handlers/VaultsSecretsEdit.ts
+++ b/src/client/handlers/VaultsSecretsEdit.ts
@@ -1,50 +1,101 @@
 import type { DB } from '@matrixai/db';
-import type {
-  ClientRPCRequestParams,
-  ClientRPCResponseResult,
-  SecretContentMessage,
-  SuccessMessage,
-} from '../types';
 import type VaultManager from '../../vaults/VaultManager';
-import { UnaryHandler } from '@matrixai/rpc';
+import { ReadableStream } from 'stream/web';
+import { JSONObject, JSONRPCRequest, RawHandler } from '@matrixai/rpc';
+import { validateSync } from '../../validation';
+import { matchSync } from '../../utils';
+import { fileTree } from '../../vaults';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
 import * as vaultOps from '../../vaults/VaultOps';
+import * as validationErrors from '../../validation/errors';
+import { ContentNode } from '@/vaults/types';
 
-class VaultsSecretsEdit extends UnaryHandler<
-  {
-    vaultManager: VaultManager;
-    db: DB;
-  },
-  ClientRPCRequestParams<SecretContentMessage>,
-  ClientRPCResponseResult<SuccessMessage>
-> {
+class VaultsSecretsEdit extends RawHandler<{
+  vaultManager: VaultManager;
+  db: DB;
+}> {
   public handle = async (
-    input: ClientRPCRequestParams<SecretContentMessage>,
-  ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
+    input: [JSONRPCRequest, ReadableStream<Uint8Array>],
+  ): Promise<[JSONObject, ReadableStream<Uint8Array>]> => {
     const { vaultManager, db } = this.container;
+    const [headerMessage, secretContentStream] = input;
+    const params = headerMessage.params;
+
+    if (params == null) {
+      throw new validationErrors.ErrorParse('Input params cannot be undefined');
+    }
+
+    const {
+      nameOrId,
+      secretNames,
+    }: { nameOrId: string; secretNames: Array<string> } = validateSync(
+      (keyPath, value) => {
+        return matchSync(keyPath)(
+          [
+            ['nameOrId'],
+            () => {
+              if (typeof value != 'string') {
+                throw new validationErrors.ErrorParse(
+                  'Parameter must be of type string',
+                );
+              }
+              return value as string;
+            },
+          ],
+          [
+            ['secretNames'],
+            () => {
+              if (
+                !Array.isArray(value) ||
+                value.length === 0 ||
+                !value.every((v) => typeof v === 'string')
+              ) {
+                throw new validationErrors.ErrorParse(
+                  'Parameter must be a non-empty array of strings',
+                );
+              }
+              return value as Array<string>;
+            },
+          ],
+          () => value,
+        );
+      },
+      {
+        nameOrId: params.nameOrId,
+        secretNames: params.secretNames,
+      },
+    );
+
+    const data: Array<ContentNode | Uint8Array> = [];
+    const dataStream = secretContentStream.pipeThrough(
+      fileTree.parserTransformStreamFactory(),
+    );
+    for await (const chunk of dataStream) data.push(chunk);
+    const secretContents = data
+      .filter((v) => v instanceof Uint8Array)
+      .map((v) => Buffer.from(v as Uint8Array).toString());
+
     await db.withTransactionF(async (tran) => {
-      const vaultIdFromName = await vaultManager.getVaultId(
-        input.nameOrId,
-        tran,
-      );
-      const vaultId =
-        vaultIdFromName ?? vaultsUtils.decodeVaultId(input.nameOrId);
+      const vaultIdFromName = await vaultManager.getVaultId(nameOrId, tran);
+      const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(nameOrId);
       if (vaultId == null) {
         throw new vaultsErrors.ErrorVaultsVaultUndefined();
       }
-      const secretContent = Buffer.from(input.secretContent, 'binary');
+
       await vaultManager.withVaults(
         [vaultId],
         async (vault) => {
-          await vaultOps.updateSecret(vault, input.secretName, secretContent);
+          for (let i = 0; i < secretNames.length; i++) {
+            const name = secretNames[i];
+            const content = secretContents[i];
+            await vaultOps.updateSecret(vault, name, content);
+          }
         },
         tran,
       );
     });
-    return {
-      success: true,
-    };
+    return [{ success: true }, new ReadableStream()];
   };
 }
 

--- a/src/client/handlers/VaultsSecretsGet.ts
+++ b/src/client/handlers/VaultsSecretsGet.ts
@@ -75,25 +75,23 @@ class VaultsSecretsGet extends RawHandler<{
           throw new vaultsErrors.ErrorVaultsVaultUndefined();
         }
         // Get secret contents
-        yield* vaultManager.withVaultsG([vaultId], (vault) => {
-          return vault.readG(async function* (fs): AsyncGenerator<
-            Uint8Array,
-            void,
-            void
-          > {
-            const contents = fileTree.serializerStreamFactory(fs, secretNames);
-            try {
+        yield* vaultManager.withVaultsG(
+          [vaultId],
+          (vault) => {
+            return vault.readG(async function* (fs): AsyncGenerator<
+              Uint8Array,
+              void,
+              void
+            > {
+              const contents = fileTree.serializerStreamFactory(
+                fs,
+                secretNames,
+              );
               for await (const chunk of contents) yield chunk;
-            } catch (e) {
-              if (e.name === 'ErrorSecretsSecretUndefined') {
-                throw new vaultsErrors.ErrorSecretsSecretUndefined(e.message, {
-                  cause: e.cause,
-                });
-              }
-              throw e;
-            }
-          });
-        });
+            });
+          },
+          tran,
+        );
       },
     );
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -560,8 +560,12 @@ function asyncGeneratorToStream<T>(
         if (done) controller.close();
         else controller.enqueue(value);
       } catch (e) {
+        console.error('from generator: ', e)
         controller.error(e);
       }
+    },
+    cancel: async (reason) => {
+      await generator.throw(reason).catch(() => {});
     },
   });
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,8 +10,8 @@ import os from 'os';
 import process from 'process';
 import path from 'path';
 import nodesEvents from 'events';
+import { ReadableStream } from 'stream/web';
 import lexi from 'lexicographic-integer';
-import { ReadableStream } from 'stream/web'
 import { PromiseCancellable } from '@matrixai/async-cancellable';
 import { timedCancellable } from '@matrixai/contexts/dist/functions';
 import * as utilsErrors from './errors';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -560,7 +560,7 @@ function asyncGeneratorToStream<T>(
         if (done) controller.close();
         else controller.enqueue(value);
       } catch (e) {
-        console.error('from generator: ', e)
+        console.error("from generator, ", e);
         controller.error(e);
       }
     },

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,6 +11,7 @@ import process from 'process';
 import path from 'path';
 import nodesEvents from 'events';
 import lexi from 'lexicographic-integer';
+import { ReadableStream } from 'stream/web'
 import { PromiseCancellable } from '@matrixai/async-cancellable';
 import { timedCancellable } from '@matrixai/contexts/dist/functions';
 import * as utilsErrors from './errors';
@@ -544,15 +545,8 @@ function setMaxListeners(
 async function* streamToAsyncGenerator<T>(
   stream: ReadableStream<T>,
 ): AsyncGenerator<T, void, unknown> {
-  const reader = stream.getReader();
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value !== undefined) yield value!;
-    }
-  } finally {
-    reader.releaseLock();
+  for await (const chunk of stream) {
+    yield chunk;
   }
 }
 

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -433,7 +433,11 @@ class VaultInternal {
   ): AsyncGenerator<T, TReturn, TNext> {
     const efsVault = this.efsVault;
     return withG([this.lock.read()], async function* () {
-      return yield* g(efsVault);
+      try {
+        return yield* g(efsVault);
+      } catch (e) {
+        throw e;
+      }
     });
   }
 

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -1046,9 +1046,13 @@ class VaultManager {
     tran?: DBTransaction,
   ): AsyncGenerator<T, Treturn, Tnext> {
     if (tran == null) {
-      return yield* this.db.withTransactionG((tran) =>
-        this.withVaultsG(vaultIds, g, tran),
-      );
+      try {
+        return yield* this.db.withTransactionG((tran) =>
+          this.withVaultsG(vaultIds, g, tran),
+        );
+      } catch (e) {
+        throw e;
+      }
     }
 
     // Obtaining locks

--- a/src/vaults/types.ts
+++ b/src/vaults/types.ts
@@ -145,7 +145,6 @@ type TreeNode = {
 
 type ContentNode = {
   type: 'CONTENT';
-  iNode: number;
   dataSize: bigint;
 };
 type DoneMessage = { type: 'DONE' };
@@ -181,12 +180,11 @@ type HeaderGeneric = {
 };
 type HeaderContent = {
   dataSize: bigint;
-  iNode: number;
 };
 
 enum HeaderSize {
   GENERIC = 2,
-  CONTENT = 13,
+  CONTENT = 9,
 }
 
 enum HeaderType {

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -1,6 +1,7 @@
 import type { TLSConfig } from '@/network/types';
 import type { FileSystem } from '@/types';
 import type { VaultId } from '@/ids';
+import type { ContentNode } from '@/vaults/types';
 import type NodeManager from '@/nodes/NodeManager';
 import type {
   LogEntryMessage,
@@ -15,6 +16,7 @@ import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
 import { RPCClient } from '@matrixai/rpc';
 import { WebSocketClient } from '@matrixai/ws';
+import { fileTree } from '@/vaults';
 import TaskManager from '@/tasks/TaskManager';
 import ACL from '@/acl/ACL';
 import KeyRing from '@/keys/KeyRing';
@@ -1449,12 +1451,26 @@ describe('vaultsSecretsNew and vaultsSecretsDelete, vaultsSecretsGet', () => {
     });
     expect(createResponse.success).toBeTruthy();
     // Get secret
-    const getResponse1 = await rpcClient.methods.vaultsSecretsGet({
+    await testsUtils.expectRemoteError(
+      rpcClient.methods.vaultsSecretsGet({
+        nameOrId: vaultIdEncoded,
+        secretNames: ['doesnt-exist'],
+      }),
+      vaultsErrors.ErrorSecretsSecretUndefined,
+    );
+    const getResponse = await rpcClient.methods.vaultsSecretsGet({
       nameOrId: vaultIdEncoded,
-      secretName: secret,
+      secretNames: [secret],
     });
-    const secretContent = getResponse1.secretContent;
-    expect(secretContent).toStrictEqual(secret);
+    const data: Array<ContentNode | Uint8Array> = [];
+    const dataStream = getResponse.readable.pipeThrough(
+      fileTree.parserTransformStreamFactory(),
+    );
+    for await (const chunk of dataStream) data.push(chunk);
+    const secretContent = data
+      .filter((v) => v instanceof Uint8Array)
+      .map((v) => Buffer.from(v as Uint8Array).toString());
+    expect(secretContent).toStrictEqual([secret]);
     // Delete secret
     const deleteResponse = await rpcClient.methods.vaultsSecretsDelete({
       nameOrId: vaultIdEncoded,
@@ -1465,45 +1481,11 @@ describe('vaultsSecretsNew and vaultsSecretsDelete, vaultsSecretsGet', () => {
     await testsUtils.expectRemoteError(
       rpcClient.methods.vaultsSecretsGet({
         nameOrId: vaultIdEncoded,
-        secretName: secret,
+        secretNames: [secret],
       }),
       vaultsErrors.ErrorSecretsSecretUndefined,
     );
   });
-  // TODO: TEST
-  test('view output', async () => {
-    const secret = 'test-secret';
-    const vaultId = await vaultManager.createVault('test-vault');
-    const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
-    await rpcClient.methods.vaultsSecretsNew({
-      nameOrId: vaultIdEncoded,
-      secretName: secret,
-      secretContent: Buffer.from('test-secret-contents-1').toString('binary'),
-    });
-    await rpcClient.methods.vaultsSecretsNew({
-      nameOrId: vaultIdEncoded,
-      secretName: 's2',
-      secretContent: Buffer.from('test-secret-contents-abc').toString('binary'),
-    });
-    const response = await rpcClient.methods.vaultsSecretsGet({
-      nameOrId: vaultIdEncoded,
-      secretNames: ['test-secret','s2'],
-    });
-    // const secretContent = response.meta?.result;
-    const data: Array<Uint8Array> = [];
-    for await (const d of response.readable) data.push(d);
-    // console.log(new TextDecoder().decode(Buffer.concat(data)));
-    const output = Buffer.concat(data)
-      .toString('utf-8')
-      .split('')
-      .map(char => {
-        const code = char.charCodeAt(0);
-        return code >= 32 && code <= 126 ? char : `\\x${code.toString(16).padStart(2, '0')}`;
-      })
-      .join('');
-    console.log(output);
-
-  })
 });
 describe('vaultsSecretsNewDir and vaultsSecretsList', () => {
   const logger = new Logger('vaultsSecretsNewDirList test', LogLevel.WARN, [

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -1451,13 +1451,13 @@ describe('vaultsSecretsNew and vaultsSecretsDelete, vaultsSecretsGet', () => {
     });
     expect(createResponse.success).toBeTruthy();
     // Get secret
-    await testsUtils.expectRemoteError(
-      rpcClient.methods.vaultsSecretsGet({
-        nameOrId: vaultIdEncoded,
-        secretNames: ['doesnt-exist'],
-      }),
-      vaultsErrors.ErrorSecretsSecretUndefined,
-    );
+    const doesntExistResponse = await rpcClient.methods.vaultsSecretsGet({
+      nameOrId: '',
+      secretNames: [secret],
+    });
+    await expect(async () => {
+      for await (const _ of doesntExistResponse.readable); // Consume values
+    }).rejects.toThrow('lol');
     const getResponse = await rpcClient.methods.vaultsSecretsGet({
       nameOrId: vaultIdEncoded,
       secretNames: [secret],
@@ -1478,13 +1478,17 @@ describe('vaultsSecretsNew and vaultsSecretsDelete, vaultsSecretsGet', () => {
     });
     expect(deleteResponse.success).toBeTruthy();
     // Check secret was deleted
-    await testsUtils.expectRemoteError(
-      rpcClient.methods.vaultsSecretsGet({
-        nameOrId: vaultIdEncoded,
-        secretNames: [secret],
-      }),
-      vaultsErrors.ErrorSecretsSecretUndefined,
-    );
+    const secretDeletedResponse = await rpcClient.methods.vaultsSecretsGet({
+      nameOrId: vaultIdEncoded,
+      secretNames: [secret],
+    });
+    await expect(async () => {
+      try {
+        for await (const _ of secretDeletedResponse.readable); // Consume values
+      } catch (e) {
+        throw e.cause;
+      }
+    }).rejects.toThrow(vaultsErrors.ErrorSecretsSecretUndefined);
   });
 });
 describe('vaultsSecretsNewDir and vaultsSecretsList', () => {

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -17,6 +17,7 @@ const expectRemoteError = async <T>(
   try {
     return await promise;
   } catch (e) {
+    console.error(e.cause);
     expect(e.cause).toBeInstanceOf(error);
   }
 };

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -17,7 +17,6 @@ const expectRemoteError = async <T>(
   try {
     return await promise;
   } catch (e) {
-    console.error(e.cause);
     expect(e.cause).toBeInstanceOf(error);
   }
 };

--- a/tests/vaults/VaultOps.test.ts
+++ b/tests/vaults/VaultOps.test.ts
@@ -579,21 +579,15 @@ describe('VaultOps', () => {
     });
     test('serializer with content works with efs', async () => {
       const data = await vault.readF(async (fs) => {
-        const fileTreeGen = fileTree.globWalk({
-          fs,
-          yieldStats: false,
-          yieldRoot: false,
-          yieldFiles: true,
-          yieldParents: true,
-          yieldDirectories: true,
-        });
         const data: Array<TreeNode | ContentNode | Uint8Array> = [];
         const parserTransform = fileTree.parserTransformStreamFactory();
-        const serializedStream = fileTree.serializerStreamFactory(
-          fs,
-          fileTreeGen,
-          true,
-        );
+        const serializedStream = fileTree.serializerStreamFactory(fs, [
+          file0b,
+          file1a,
+          file2b,
+          file3a,
+          file4b,
+        ]);
         const outputStream = serializedStream.pipeThrough(parserTransform);
         for await (const output of outputStream) {
           data.push(output);

--- a/tests/vaults/fileTree.test.ts
+++ b/tests/vaults/fileTree.test.ts
@@ -1,10 +1,10 @@
-import type { ContentNode, FileTree, TreeNode } from '@/vaults/types';
+import type { ContentNode, FileTree } from '@/vaults/types';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { ReadableStream } from 'stream/web';
 import { test } from '@fast-check/jest';
-import fc, { uint8Array } from 'fast-check';
+import fc from 'fast-check';
 import * as fileTree from '@/vaults/fileTree';
 import * as vaultsTestUtils from './utils';
 
@@ -494,12 +494,11 @@ describe('fileTree', () => {
         yieldParents: true,
         yieldDirectories: true,
       });
-      const data: Array<TreeNode | ContentNode | Uint8Array> = [];
+      const data: Array<ContentNode | Uint8Array> = [];
       const parserTransform = fileTree.parserTransformStreamFactory();
       const serializedStream = fileTree.serializerStreamFactory(
         fs,
         fileTreeGen,
-        false,
       );
       const outputStream = serializedStream.pipeThrough(parserTransform);
       for await (const output of outputStream) {
@@ -537,7 +536,7 @@ describe('fileTree', () => {
         yieldParents: true,
         yieldDirectories: true,
       });
-      const data: Array<TreeNode | ContentNode | Uint8Array> = [];
+      const data: Array<ContentNode | Uint8Array> = [];
       const snipperTransform = vaultsTestUtils.binaryStreamToSnippedStream([
         5, 7, 11, 13,
       ]);
@@ -545,7 +544,6 @@ describe('fileTree', () => {
       const serializedStream = fileTree.serializerStreamFactory(
         fs,
         fileTreeGen,
-        false,
       );
       const outputStream = serializedStream
         .pipeThrough(snipperTransform)
@@ -588,7 +586,6 @@ describe('fileTree', () => {
             yieldParents: true,
             yieldDirectories: true,
           }),
-          false,
         );
         const stream2 = fileTree.serializerStreamFactory(
           fs,
@@ -600,7 +597,6 @@ describe('fileTree', () => {
             yieldParents: true,
             yieldDirectories: true,
           }),
-          false,
         );
         return new ReadableStream({
           start: async (controller) => {
@@ -610,7 +606,7 @@ describe('fileTree', () => {
           },
         });
       }
-      const data: Array<TreeNode | ContentNode | Uint8Array> = [];
+      const data: Array<ContentNode | Uint8Array> = [];
       const parserTransform = fileTree.parserTransformStreamFactory();
       // Const serializedStream = fileTree.serializerStreamFactory(fileTreeGen);
       const serializedStream = doubleWalkFactory();
@@ -657,12 +653,11 @@ describe('fileTree', () => {
         yieldParents: false,
         yieldDirectories: false,
       });
-      const data: Array<TreeNode | ContentNode | Uint8Array> = [];
+      const data: Array<ContentNode | Uint8Array> = [];
       const parserTransform = fileTree.parserTransformStreamFactory();
       const serializedStream = fileTree.serializerStreamFactory(
         fs,
         fileTreeGen,
-        true,
       );
       const outputStream = serializedStream.pipeThrough(parserTransform);
       for await (const output of outputStream) {
@@ -707,9 +702,7 @@ describe('fileTree', () => {
       const parserTransform = fileTree.parserTransformStreamFactory();
       const outputStream = dataStream.pipeThrough(parserTransform);
       try {
-        for await (const _ of outputStream) {
-          // Only consume
-        }
+        for await (const _ of outputStream); // Consume values
       } catch {
         return;
       }
@@ -729,17 +722,13 @@ describe('fileTree', () => {
         yieldParents: false,
         yieldDirectories: false,
       });
-      let serializedStream = fileTree.serializerStreamFactory(fs, fileTreeGen);
-      // const data: Array<Uint8Array> = [];
-      // for await (const d of serializedStream) {
-      //   data.push(d);
-      // }
-      // console.log(data.map((v) => Buffer.from(v as Uint8Array).toString()));
-
-      // serializedStream = fileTree.serializerStreamFactory(fs, fileTreeGen);
+      const serializedStream = fileTree.serializerStreamFactory(
+        fs,
+        fileTreeGen,
+      );
       const parserTransform = fileTree.parserTransformStreamFactory();
       const outputStream = serializedStream.pipeThrough(parserTransform);
-      const output: Array<string> = [];
+      const output: Array<ContentNode | Uint8Array> = [];
       for await (const d of outputStream) {
         output.push(d);
       }

--- a/tests/vaults/fileTree.test.ts
+++ b/tests/vaults/fileTree.test.ts
@@ -722,10 +722,9 @@ describe('fileTree', () => {
         yieldParents: false,
         yieldDirectories: false,
       });
-      const serializedStream = fileTree.serializerStreamFactory(
-        fs,
-        fileTreeGen,
-      );
+      const data: Array<string> = [];
+      for await (const p of fileTreeGen) data.push(p.path);
+      const serializedStream = fileTree.serializerStreamFactory(fs, data);
       const parserTransform = fileTree.parserTransformStreamFactory();
       const outputStream = serializedStream.pipeThrough(parserTransform);
       const output: Array<ContentNode | Uint8Array> = [];

--- a/tests/vaults/fileTree.test.ts
+++ b/tests/vaults/fileTree.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import { ReadableStream } from 'stream/web';
 import { test } from '@fast-check/jest';
-import fc from 'fast-check';
+import fc, { uint8Array } from 'fast-check';
 import * as fileTree from '@/vaults/fileTree';
 import * as vaultsTestUtils from './utils';
 
@@ -718,5 +718,32 @@ describe('fileTree', () => {
     // TODO: tests for
     //  - empty files
     //  - files larger than content chunks
+
+    // TEST: DEBUGGGG
+    test('view serializer', async () => {
+      const fileTreeGen = fileTree.globWalk({
+        fs,
+        yieldStats: false,
+        yieldRoot: false,
+        yieldFiles: true,
+        yieldParents: false,
+        yieldDirectories: false,
+      });
+      let serializedStream = fileTree.serializerStreamFactory(fs, fileTreeGen);
+      // const data: Array<Uint8Array> = [];
+      // for await (const d of serializedStream) {
+      //   data.push(d);
+      // }
+      // console.log(data.map((v) => Buffer.from(v as Uint8Array).toString()));
+
+      // serializedStream = fileTree.serializerStreamFactory(fs, fileTreeGen);
+      const parserTransform = fileTree.parserTransformStreamFactory();
+      const outputStream = serializedStream.pipeThrough(parserTransform);
+      const output: Array<string> = [];
+      for await (const d of outputStream) {
+        output.push(d);
+      }
+      console.log(output);
+    });
   });
 });

--- a/tests/vaults/utils.ts
+++ b/tests/vaults/utils.ts
@@ -24,7 +24,6 @@ const headerGenericArb = fc.record<HeaderGeneric>({
 });
 const headerContentArb = fc.record<HeaderContent>({
   dataSize: fc.bigUint({ max: 2n ** 63n }),
-  iNode: fc.nat(),
 });
 
 /**


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
Currently, `VaultsSecretsGet` and `VaultsSecretsEdit` are `UnaryHandler`s, which poses many restrictions on its functionality, and especially impacts speed and performance. As such, I will be replacing them by a trimmed-down version of `fileTree.serializerStreamFactory` and `fileTree.parserTransformStreamFactory`. (https://github.com/MatrixAI/Polykey/pull/785#issuecomment-2285129501, https://github.com/MatrixAI/Polykey/pull/785#issuecomment-2306121391).

This PR will also remove the two aforementioned RPC methods, instead introducing two new methods, `VaultsSecretsGet` and `VaultSecretsSet` for doing the same, but using `RawHandler`s instead. (https://github.com/MatrixAI/Polykey-CLI/pull/267#issuecomment-2311693017). 

This is important for many UNIX commands like `secrets edit`, `secrets cat`, etc.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to https://github.com/MatrixAI/Polykey-CLI/issues/266
* REF ENG-398

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Trim functionality of `parserTransformerStreamFactory` and `serializerStreamFactory`
- [ ] 2. Update `VaultsSecretsGet`
- [ ] 3. Update `VaultsSecretsEdit` to `VaultsSecretsSet`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
