### PR TITLE
Updating behaviour of `VaultsSecretsGet` to align with requirements of `secrets cat`

### DIFF
--- a/src/client/callers/vaultsSecretsGet.ts
+++ b/src/client/callers/vaultsSecretsGet.ts
@@ -1,10 +1,10 @@
 import type { HandlerTypes } from '@matrixai/rpc';
 import type VaultsSecretsGet from '../handlers/VaultsSecretsGet';
-import { UnaryCaller } from '@matrixai/rpc';
+import { DuplexCaller } from '@matrixai/rpc';
 
 type CallerTypes = HandlerTypes<VaultsSecretsGet>;
 
-const vaultsSecretsGet = new UnaryCaller<
+const vaultsSecretsGet = new DuplexCaller<
   CallerTypes['input'],
   CallerTypes['output']
 >();

--- a/src/client/callers/vaultsSecretsRemove.ts
+++ b/src/client/callers/vaultsSecretsRemove.ts
@@ -1,10 +1,10 @@
 import type { HandlerTypes } from '@matrixai/rpc';
 import type VaultsSecretsRemove from '../handlers/VaultsSecretsRemove';
-import { UnaryCaller } from '@matrixai/rpc';
+import { ClientCaller } from '@matrixai/rpc';
 
 type CallerTypes = HandlerTypes<VaultsSecretsRemove>;
 
-const vaultsSecretsRemove = new UnaryCaller<
+const vaultsSecretsRemove = new ClientCaller<
   CallerTypes['input'],
   CallerTypes['output']
 >();

--- a/src/client/handlers/VaultsSecretsGet.ts
+++ b/src/client/handlers/VaultsSecretsGet.ts
@@ -2,47 +2,71 @@ import type { DB } from '@matrixai/db';
 import type {
   ClientRPCRequestParams,
   ClientRPCResponseResult,
-  ContentMessage,
+  ContentWithErrorMessage,
   SecretIdentifierMessage,
 } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
-import { UnaryHandler } from '@matrixai/rpc';
+import { DuplexHandler } from '@matrixai/rpc';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
 import * as vaultOps from '../../vaults/VaultOps';
 
-class VaultsSecretsGet extends UnaryHandler<
+class VaultsSecretsGet extends DuplexHandler<
   {
     vaultManager: VaultManager;
     db: DB;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
-  ClientRPCResponseResult<ContentMessage>
+  ClientRPCResponseResult<ContentWithErrorMessage>
 > {
-  public handle = async (
-    input: ClientRPCRequestParams<SecretIdentifierMessage>,
-  ): Promise<ClientRPCResponseResult<ContentMessage>> => {
+  public handle = async function* (
+    input: AsyncIterable<ClientRPCRequestParams<SecretIdentifierMessage>>,
+    _cancel,
+    _meta,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<ContentWithErrorMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { vaultManager, db } = this.container;
-    return await db.withTransactionF(async (tran) => {
-      const vaultIdFromName = await vaultManager.getVaultId(
-        input.nameOrId,
-        tran,
-      );
-      const vaultId =
-        vaultIdFromName ?? vaultsUtils.decodeVaultId(input.nameOrId);
-      if (vaultId == null) {
-        throw new vaultsErrors.ErrorVaultsVaultUndefined();
+    yield* db.withTransactionG(async function* (tran): AsyncGenerator<
+      ClientRPCResponseResult<ContentWithErrorMessage>
+    > {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
+      // As we need to preserve the order of parameters, we need to loop over
+      // them individually, as grouping them would make them go out of order.
+      let metadata: any = undefined;
+      for await (const secretIdentiferMessage of input) {
+        if (ctx.signal.aborted) throw ctx.signal.reason;
+        if (metadata == null) metadata = secretIdentiferMessage.metadata ?? {};
+        const { nameOrId, secretName } = secretIdentiferMessage;
+        const vaultIdFromName = await vaultManager.getVaultId(nameOrId, tran);
+        const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(nameOrId);
+        if (vaultId == null) throw new vaultsErrors.ErrorVaultsVaultUndefined();
+        yield await vaultManager.withVaults(
+          [vaultId],
+          async (vault) => {
+            try {
+              const content = await vaultOps.getSecret(vault, secretName);
+              return { secretContent: content.toString('binary') };
+            } catch (e) {
+              if (metadata?.options?.continueOnError === true) {
+                if (e instanceof vaultsErrors.ErrorSecretsSecretUndefined) {
+                  return {
+                    secretContent: '',
+                    error: `${e.name}: ${secretName}: No such secret or directory\n`,
+                  };
+                } else if (e instanceof vaultsErrors.ErrorSecretsIsDirectory) {
+                  return {
+                    secretContent: '',
+                    error: `${e.name}: ${secretName}: Is a directory\n`,
+                  };
+                }
+              }
+              throw e;
+            }
+          },
+          tran,
+        );
       }
-      const secretContent = await vaultManager.withVaults(
-        [vaultId],
-        async (vault) => {
-          return await vaultOps.getSecret(vault, input.secretName);
-        },
-        tran,
-      );
-      return {
-        secretContent: secretContent.toString('binary'),
-      };
     });
   };
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -306,16 +306,13 @@ type SecretPathMessage = {
 
 type SecretIdentifierMessage = VaultIdentifierMessage & SecretPathMessage;
 
-type SecretRemoveMessage = {
-  secretNames: Array<Array<string>>;
-  options?: {
-    recursive?: boolean;
-  };
-};
-
 // Contains binary content as a binary string 'toString('binary')'
 type ContentMessage = {
   secretContent: string;
+};
+
+type ContentWithErrorMessage = ContentMessage & {
+  error?: string;
 };
 
 type SecretContentMessage = SecretIdentifierMessage & ContentMessage;
@@ -423,8 +420,8 @@ export type {
   VaultsLatestVersionMessage,
   SecretPathMessage,
   SecretIdentifierMessage,
-  SecretRemoveMessage,
   ContentMessage,
+  ContentWithErrorMessage,
   SecretContentMessage,
   SecretMkdirMessage,
   SecretDirMessage,


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
The current `VaultsSecretsGet` only gets a single secret from the vault, and returns it in the form of a `UnaryHandler`, meaning for large files, the RPC call will timeout. It also fetches only one file at a time, so behaviour like UNIX's `cat` command isn't possible.

This PR aims to fix that issue by switching over the RPC handler to a `ServerHandler`, supporting larger files. This PR also adds support for listing the contents of multiple files in order, like what `cat` does.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to https://github.com/MatrixAI/Polykey-CLI/issues/243
* Closes ENG-356 ([link](https://linear.app/matrix-ai/issue/ENG-356/implement-secrets-cat-command)) 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Switch `UnaryHandler` to `StreamHandler`
- [x] 2. Implement support for displaying contents of multiple files
- [x] 3. Implement support for listing multiple files across multiple vaults
- [x] 4. Update old test and add new tests

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build