### PR TITLE
Make VaultsSecretsMkdir support specifying multiple secret paths

### DIFF
--- a/src/client/callers/vaultsSecretsMkdir.ts
+++ b/src/client/callers/vaultsSecretsMkdir.ts
@@ -1,10 +1,10 @@
 import type { HandlerTypes } from '@matrixai/rpc';
 import type VaultsSecretsMkdir from '../handlers/VaultsSecretsMkdir';
-import { UnaryCaller } from '@matrixai/rpc';
+import { DuplexCaller } from '@matrixai/rpc';
 
 type CallerTypes = HandlerTypes<VaultsSecretsMkdir>;
 
-const vaultsSecretsMkdir = new UnaryCaller<
+const vaultsSecretsMkdir = new DuplexCaller<
   CallerTypes['input'],
   CallerTypes['output']
 >();

--- a/src/client/handlers/AgentLockAll.ts
+++ b/src/client/handlers/AgentLockAll.ts
@@ -12,7 +12,8 @@ class AgentLockAll extends UnaryHandler<
   ClientRPCResponseResult
 > {
   public handle = async (): Promise<ClientRPCResponseResult> => {
-    const { db, sessionManager } = this.container;
+    const { db, sessionManager }: { db: DB; sessionManager: SessionManager } =
+      this.container;
     await db.withTransactionF((tran) => sessionManager.resetKey(tran));
     return {};
   };

--- a/src/client/handlers/AgentStatus.ts
+++ b/src/client/handlers/AgentStatus.ts
@@ -18,7 +18,7 @@ class AgentStatus extends UnaryHandler<
   public handle = async (): Promise<
     ClientRPCResponseResult<StatusResultMessage>
   > => {
-    const { polykeyAgent } = this.container;
+    const { polykeyAgent }: { polykeyAgent: PolykeyAgent } = this.container;
     return {
       pid: process.pid,
       nodeIdEncoded: nodesUtils.encodeNodeId(polykeyAgent.keyRing.getNodeId()),

--- a/src/client/handlers/AgentStop.ts
+++ b/src/client/handlers/AgentStop.ts
@@ -11,7 +11,7 @@ class AgentStop extends UnaryHandler<
   ClientRPCResponseResult
 > {
   public handle = async (): Promise<ClientRPCResponseResult> => {
-    const { polykeyAgent } = this.container;
+    const { polykeyAgent }: { polykeyAgent: PolykeyAgent } = this.container;
     // If not running or in stopping status, then respond successfully
     if (!polykeyAgent[running] || polykeyAgent[status] === 'stopping') {
       return {};

--- a/src/client/handlers/AuditEventsGet.ts
+++ b/src/client/handlers/AuditEventsGet.ts
@@ -25,7 +25,7 @@ class AuditEventsGet extends ServerHandler<
   }>,
   ClientRPCResponseResult<AuditEventSerialized>
 > {
-  public async *handle(
+  public handle = async function* (
     {
       paths,
       seek,
@@ -46,7 +46,7 @@ class AuditEventsGet extends ServerHandler<
     _meta,
     ctx: ContextTimed,
   ): AsyncGenerator<ClientRPCResponseResult<AuditEventSerialized>> {
-    const { audit } = this.container;
+    const { audit }: { audit: Audit } = this.container;
     const iterators: Array<AsyncGenerator<AuditEvent>> = [];
     let seek_: AuditEventId | number | undefined;
     if (seek != null) {
@@ -109,7 +109,7 @@ class AuditEventsGet extends ServerHandler<
         data: auditEvent.data,
       };
     }
-  }
+  };
 }
 
 export default AuditEventsGet;

--- a/src/client/handlers/AuditMetricGet.ts
+++ b/src/client/handlers/AuditMetricGet.ts
@@ -35,7 +35,7 @@ class AuditMetricGet extends UnaryHandler<
     _meta,
     _ctx,
   ): Promise<ClientRPCResponseResult<MetricPathToAuditMetric<T>>> => {
-    const { audit } = this.container;
+    const { audit }: { audit: Audit } = this.container;
     let seek_: AuditEventId | number | undefined;
     if (seek != null) {
       seek_ =

--- a/src/client/handlers/GestaltsActionsGetByIdentity.ts
+++ b/src/client/handlers/GestaltsActionsGetByIdentity.ts
@@ -29,7 +29,8 @@ class GestaltsActionsGetByIdentity extends UnaryHandler<
       actionsList: Array<GestaltAction>;
     }>
   > => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/GestaltsActionsGetByNode.ts
+++ b/src/client/handlers/GestaltsActionsGetByNode.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsActionsGetByNode extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<NodeIdMessage>,
   ClientRPCResponseResult<ActionsListMessage>
@@ -24,7 +24,8 @@ class GestaltsActionsGetByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
   ): Promise<ClientRPCResponseResult<ActionsListMessage>> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const { nodeId }: { nodeId: NodeId } = validateSync(
       (keyPath, value) => {
         return matchSync(keyPath)(

--- a/src/client/handlers/GestaltsActionsSetByIdentity.ts
+++ b/src/client/handlers/GestaltsActionsSetByIdentity.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsActionsSetByIdentityHandler extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<SetIdentityActionMessage>,
   ClientRPCResponseResult
@@ -24,7 +24,8 @@ class GestaltsActionsSetByIdentityHandler extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SetIdentityActionMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const {
       action,
       providerId,

--- a/src/client/handlers/GestaltsActionsSetByNode.ts
+++ b/src/client/handlers/GestaltsActionsSetByNode.ts
@@ -24,7 +24,8 @@ class GestaltsActionsSetByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SetNodeActionMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const { nodeId, action }: { nodeId: NodeId; action: GestaltAction } =
       validateSync(
         (keyPath, value) => {

--- a/src/client/handlers/GestaltsActionsUnsetByIdentity.ts
+++ b/src/client/handlers/GestaltsActionsUnsetByIdentity.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsActionsUnsetByIdentity extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<SetIdentityActionMessage>,
   ClientRPCResponseResult
@@ -24,7 +24,8 @@ class GestaltsActionsUnsetByIdentity extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SetIdentityActionMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const {
       action,
       providerId,

--- a/src/client/handlers/GestaltsActionsUnsetByNode.ts
+++ b/src/client/handlers/GestaltsActionsUnsetByNode.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsActionsUnsetByNode extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<SetNodeActionMessage>,
   ClientRPCResponseResult
@@ -24,7 +24,8 @@ class GestaltsActionsUnsetByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SetNodeActionMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const { nodeId, action }: { nodeId: NodeId; action: GestaltAction } =
       validateSync(
         (keyPath, value) => {

--- a/src/client/handlers/GestaltsDiscoveryByIdentity.ts
+++ b/src/client/handlers/GestaltsDiscoveryByIdentity.ts
@@ -20,7 +20,7 @@ class GestaltsDiscoveryByIdentity extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { discovery } = this.container;
+    const { discovery }: { discovery: Discovery } = this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/GestaltsDiscoveryByNode.ts
+++ b/src/client/handlers/GestaltsDiscoveryByNode.ts
@@ -20,7 +20,7 @@ class GestaltsDiscoveryByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { discovery } = this.container;
+    const { discovery }: { discovery: Discovery } = this.container;
     const { nodeId }: { nodeId: NodeId } = validateSync(
       (keyPath, value) => {
         return matchSync(keyPath)(

--- a/src/client/handlers/GestaltsDiscoveryQueue.ts
+++ b/src/client/handlers/GestaltsDiscoveryQueue.ts
@@ -11,18 +11,18 @@ class GestaltsDiscoveryQueue extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<DiscoveryQueueInfo>
 > {
-  public async *handle(
+  public handle = async function* (
     _input: ClientRPCRequestParams,
     _cancel,
     _meta,
     ctx: ContextTimed,
   ): AsyncGenerator<ClientRPCResponseResult<DiscoveryQueueInfo>> {
-    const { discovery } = this.container;
+    const { discovery }: { discovery: Discovery } = this.container;
     for await (const discoveryQueueInfo of discovery.getDiscoveryQueue()) {
       ctx.signal.throwIfAborted();
       yield discoveryQueueInfo;
     }
-  }
+  };
 }
 
 export default GestaltsDiscoveryQueue;

--- a/src/client/handlers/GestaltsGestaltGetByIdentity.ts
+++ b/src/client/handlers/GestaltsGestaltGetByIdentity.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsGestaltGetByIdentity extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<IdentityMessage>,
   ClientRPCResponseResult<GestaltMessage>
@@ -24,7 +24,8 @@ class GestaltsGestaltGetByIdentity extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult<GestaltMessage>> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/GestaltsGestaltGetByNode.ts
+++ b/src/client/handlers/GestaltsGestaltGetByNode.ts
@@ -15,8 +15,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsGestaltGetByNode extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams<NodeIdMessage>,
   ClientRPCResponseResult<GestaltMessage>
@@ -24,7 +24,8 @@ class GestaltsGestaltGetByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
   ): Promise<ClientRPCResponseResult<GestaltMessage>> => {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     const { nodeId }: { nodeId: NodeId } = validateSync(
       (keyPath, value) => {
         return matchSync(keyPath)(

--- a/src/client/handlers/GestaltsGestaltList.ts
+++ b/src/client/handlers/GestaltsGestaltList.ts
@@ -10,19 +10,20 @@ import * as nodesUtils from '../../nodes/utils';
 
 class GestaltsGestaltList extends ServerHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
   },
   ClientRPCRequestParams,
   ClientRPCResponseResult<GestaltMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     _input,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<GestaltMessage>> {
-    const { db, gestaltGraph } = this.container;
+    const { db, gestaltGraph }: { db: DB; gestaltGraph: GestaltGraph } =
+      this.container;
     yield* db.withTransactionG(async function* (tran): AsyncGenerator<
       ClientRPCResponseResult<GestaltMessage>
     > {
@@ -57,7 +58,7 @@ class GestaltsGestaltList extends ServerHandler<
         yield gestaltMessage;
       }
     });
-  }
+  };
 }
 
 export default GestaltsGestaltList;

--- a/src/client/handlers/GestaltsGestaltTrustByIdentity.ts
+++ b/src/client/handlers/GestaltsGestaltTrustByIdentity.ts
@@ -14,8 +14,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsGestaltTrustByIdentity extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
     discovery: Discovery;
   },
   ClientRPCRequestParams<IdentityMessage>,
@@ -24,7 +24,12 @@ class GestaltsGestaltTrustByIdentity extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph, discovery } = this.container;
+    const {
+      db,
+      gestaltGraph,
+      discovery,
+    }: { db: DB; gestaltGraph: GestaltGraph; discovery: Discovery } =
+      this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/GestaltsGestaltTrustByNode.ts
+++ b/src/client/handlers/GestaltsGestaltTrustByNode.ts
@@ -14,8 +14,8 @@ import { matchSync } from '../../utils';
 
 class GestaltsGestaltTrustByNode extends UnaryHandler<
   {
-    gestaltGraph: GestaltGraph;
     db: DB;
+    gestaltGraph: GestaltGraph;
     discovery: Discovery;
   },
   ClientRPCRequestParams<NodeIdMessage>,
@@ -24,7 +24,12 @@ class GestaltsGestaltTrustByNode extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, gestaltGraph, discovery } = this.container;
+    const {
+      db,
+      gestaltGraph,
+      discovery,
+    }: { db: DB; gestaltGraph: GestaltGraph; discovery: Discovery } =
+      this.container;
     const { nodeId }: { nodeId: NodeId } = validateSync(
       (keyPath, value) => {
         return matchSync(keyPath)(

--- a/src/client/handlers/IdentitiesAuthenticate.ts
+++ b/src/client/handlers/IdentitiesAuthenticate.ts
@@ -15,22 +15,19 @@ class IdentitiesAuthenticate extends ServerHandler<
   {
     identitiesManager: IdentitiesManager;
   },
-  ClientRPCRequestParams<{
-    providerId: string;
-  }>,
+  ClientRPCRequestParams<{ providerId: string }>,
   ClientRPCResponseResult<AuthProcessMessage>
 > {
   public timeout = 120000; // 2 Minutes
-  public async *handle(
-    input: ClientRPCRequestParams<{
-      providerId: string;
-    }>,
+  public handle = async function* (
+    input: ClientRPCRequestParams<{ providerId: string }>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<AuthProcessMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     const {
       providerId,
     }: {
@@ -72,7 +69,7 @@ class IdentitiesAuthenticate extends ServerHandler<
         identityId: authFlowResult.value,
       },
     };
-  }
+  };
 }
 
 export default IdentitiesAuthenticate;

--- a/src/client/handlers/IdentitiesAuthenticatedGet.ts
+++ b/src/client/handlers/IdentitiesAuthenticatedGet.ts
@@ -14,21 +14,18 @@ class IdentitiesAuthenticatedGet extends ServerHandler<
   {
     identitiesManager: IdentitiesManager;
   },
-  ClientRPCRequestParams<{
-    providerId?: string;
-  }>,
+  ClientRPCRequestParams<{ providerId?: string }>,
   ClientRPCResponseResult<IdentityMessage>
 > {
-  public async *handle(
-    input: ClientRPCRequestParams<{
-      providerId?: string;
-    }>,
+  public handle = async function* (
+    input: ClientRPCRequestParams<{ providerId?: string }>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     let providerId: ProviderId | undefined;
     if (input.providerId != null) {
       providerId = validateSync(
@@ -61,7 +58,7 @@ class IdentitiesAuthenticatedGet extends ServerHandler<
         };
       }
     }
-  }
+  };
 }
 
 export default IdentitiesAuthenticatedGet;

--- a/src/client/handlers/IdentitiesClaim.ts
+++ b/src/client/handlers/IdentitiesClaim.ts
@@ -21,7 +21,8 @@ class IdentitiesClaim extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult<ClaimIdMessage>> => {
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/IdentitiesInfoConnectedGet.ts
+++ b/src/client/handlers/IdentitiesInfoConnectedGet.ts
@@ -20,14 +20,15 @@ class IdentitiesInfoConnectedGet extends ServerHandler<
   ClientRPCRequestParams<ProviderSearchMessage>,
   ClientRPCResponseResult<IdentityInfoMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<ProviderSearchMessage>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     const {
       providerIds,
     }: {
@@ -105,7 +106,7 @@ class IdentitiesInfoConnectedGet extends ServerHandler<
         count++;
       }
     }
-  }
+  };
 }
 
 export default IdentitiesInfoConnectedGet;

--- a/src/client/handlers/IdentitiesInfoGet.ts
+++ b/src/client/handlers/IdentitiesInfoGet.ts
@@ -21,14 +21,15 @@ class IdentitiesInfoGet extends ServerHandler<
   ClientRPCRequestParams<ProviderSearchMessage>,
   ClientRPCResponseResult<IdentityInfoMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<ProviderSearchMessage>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     const {
       providerIds,
       identityId,
@@ -99,7 +100,7 @@ class IdentitiesInfoGet extends ServerHandler<
         }
       }
     }
-  }
+  };
 }
 
 export default IdentitiesInfoGet;

--- a/src/client/handlers/IdentitiesInvite.ts
+++ b/src/client/handlers/IdentitiesInvite.ts
@@ -24,7 +24,15 @@ class IdentitiesInvite extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<ClaimNodeMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { acl, notificationsManager, logger } = this.container;
+    const {
+      acl,
+      notificationsManager,
+      logger,
+    }: {
+      acl: ACL;
+      notificationsManager: NotificationsManager;
+      logger: Logger;
+    } = this.container;
     const {
       nodeId,
     }: {

--- a/src/client/handlers/IdentitiesProvidersList.ts
+++ b/src/client/handlers/IdentitiesProvidersList.ts
@@ -16,7 +16,8 @@ class IdentitiesProvidersList extends UnaryHandler<
       providerIds: Array<string>;
     }>
   > => {
-    const { identitiesManager } = this.container;
+    const { identitiesManager }: { identitiesManager: IdentitiesManager } =
+      this.container;
     const providers = identitiesManager.getProviders();
     return {
       providerIds: Object.keys(providers),

--- a/src/client/handlers/IdentitiesTokenDelete.ts
+++ b/src/client/handlers/IdentitiesTokenDelete.ts
@@ -22,7 +22,10 @@ class IdentitiesTokenDeleteHandler extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { identitiesManager, db } = this.container;
+    const {
+      db,
+      identitiesManager,
+    }: { db: DB; identitiesManager: IdentitiesManager } = this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/IdentitiesTokenGet.ts
+++ b/src/client/handlers/IdentitiesTokenGet.ts
@@ -23,7 +23,10 @@ class IdentitiesTokenGet extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage>,
   ): Promise<ClientRPCResponseResult<Partial<TokenMessage>>> => {
-    const { identitiesManager, db } = this.container;
+    const {
+      db,
+      identitiesManager,
+    }: { db: DB; identitiesManager: IdentitiesManager } = this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/IdentitiesTokenPut.ts
+++ b/src/client/handlers/IdentitiesTokenPut.ts
@@ -23,7 +23,10 @@ class IdentitiesTokenPut extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<IdentityMessage & TokenMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { identitiesManager, db } = this.container;
+    const {
+      db,
+      identitiesManager,
+    }: { db: DB; identitiesManager: IdentitiesManager } = this.container;
     const {
       providerId,
       identityId,

--- a/src/client/handlers/KeysCertsChainGet.ts
+++ b/src/client/handlers/KeysCertsChainGet.ts
@@ -13,20 +13,20 @@ class KeysCertsChainGet extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<CertMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     _input,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<CertMessage>> {
-    const { certManager } = this.container;
+    const { certManager }: { certManager: CertManager } = this.container;
     for (const certPEM of await certManager.getCertPEMsChain()) {
       if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         cert: certPEM,
       };
     }
-  }
+  };
 }
 
 export default KeysCertsChainGet;

--- a/src/client/handlers/KeysCertsGet.ts
+++ b/src/client/handlers/KeysCertsGet.ts
@@ -14,7 +14,7 @@ class KeysCertsGet extends UnaryHandler<
   ClientRPCResponseResult<CertMessage>
 > {
   public handle = async (): Promise<ClientRPCResponseResult<CertMessage>> => {
-    const { certManager } = this.container;
+    const { certManager }: { certManager: CertManager } = this.container;
     const cert = await certManager.getCurrentCertPEM();
     return {
       cert,

--- a/src/client/handlers/KeysDecrypt.ts
+++ b/src/client/handlers/KeysDecrypt.ts
@@ -17,7 +17,7 @@ class KeysDecrypt extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<DataMessage>,
   ): Promise<ClientRPCResponseResult<DataMessage>> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     const data = keyRing.decrypt(Buffer.from(input.data, 'binary'));
     if (data == null) never();
     return {

--- a/src/client/handlers/KeysEncrypt.ts
+++ b/src/client/handlers/KeysEncrypt.ts
@@ -21,7 +21,7 @@ class KeysEncrypt extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<DecryptMessage>,
   ): Promise<ClientRPCResponseResult<DataMessage>> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
 
     let publicKey: PublicKey | undefined;
     try {

--- a/src/client/handlers/KeysKeyPair.ts
+++ b/src/client/handlers/KeysKeyPair.ts
@@ -18,7 +18,7 @@ class KeysKeyPair extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PasswordMessage>,
   ): Promise<ClientRPCResponseResult<KeyPairMessage>> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     const privateJWK = keysUtils.privateKeyToJWK(keyRing.keyPair.privateKey);
     const privateKeyJwe = keysUtils.wrapWithPassword(
       input.password,

--- a/src/client/handlers/KeysKeyPairRenew.ts
+++ b/src/client/handlers/KeysKeyPairRenew.ts
@@ -16,7 +16,7 @@ class KeysKeyPairRenew extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PasswordMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { certManager } = this.container;
+    const { certManager }: { certManager: CertManager } = this.container;
 
     // Other domains will be updated accordingly via the `EventBus` so we
     // only need to modify the KeyManager

--- a/src/client/handlers/KeysKeyPairReset.ts
+++ b/src/client/handlers/KeysKeyPairReset.ts
@@ -16,7 +16,7 @@ class KeysKeyPairReset extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PasswordMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { certManager } = this.container;
+    const { certManager }: { certManager: CertManager } = this.container;
     // Other domains will be updated accordingly via the `EventBus` so we
     // only need to modify the KeyManager
     await certManager.resetCertWithNewKeyPair(input.password);

--- a/src/client/handlers/KeysPasswordChange.ts
+++ b/src/client/handlers/KeysPasswordChange.ts
@@ -16,7 +16,7 @@ class KeysPasswordChange extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PasswordMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     await keyRing.changePassword(input.password);
     return {};
   };

--- a/src/client/handlers/KeysPublicKey.ts
+++ b/src/client/handlers/KeysPublicKey.ts
@@ -17,7 +17,7 @@ class KeysPublicKey extends UnaryHandler<
   public handle = async (): Promise<
     ClientRPCResponseResult<PublicKeyMessage>
   > => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     const publicKeyJwk = keysUtils.publicKeyToJWK(keyRing.keyPair.publicKey);
     return {
       publicKeyJwk,

--- a/src/client/handlers/KeysSign.ts
+++ b/src/client/handlers/KeysSign.ts
@@ -17,7 +17,7 @@ class KeysSign extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<DataMessage>,
   ): Promise<ClientRPCResponseResult<SignatureMessage>> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     const signature = keyRing.sign(Buffer.from(input.data, 'binary'));
     return {
       signature: signature.toString('binary'),

--- a/src/client/handlers/KeysVerify.ts
+++ b/src/client/handlers/KeysVerify.ts
@@ -21,7 +21,7 @@ class KeysVerify extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VerifySignatureMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { keyRing } = this.container;
+    const { keyRing }: { keyRing: KeyRing } = this.container;
     let publicKey: PublicKey | undefined;
     try {
       const jwk = input.publicKeyJwk;
@@ -35,9 +35,7 @@ class KeysVerify extends UnaryHandler<
       Buffer.from(input.data, 'binary'),
       Buffer.from(input.signature, 'binary') as Signature,
     );
-    return {
-      success,
-    };
+    return { type: 'success', success: success };
   };
 }
 

--- a/src/client/handlers/NodesAdd.ts
+++ b/src/client/handlers/NodesAdd.ts
@@ -16,8 +16,8 @@ import { validateSync } from '../../validation';
 
 class NodesAdd extends UnaryHandler<
   {
-    nodeManager: NodeManager;
     db: DB;
+    nodeManager: NodeManager;
   },
   ClientRPCRequestParams<NodesAddMessage>,
   ClientRPCResponseResult
@@ -25,7 +25,8 @@ class NodesAdd extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodesAddMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { nodeManager, db } = this.container;
+    const { db, nodeManager }: { db: DB; nodeManager: NodeManager } =
+      this.container;
     const {
       nodeId,
       host,

--- a/src/client/handlers/NodesClaim.ts
+++ b/src/client/handlers/NodesClaim.ts
@@ -14,8 +14,8 @@ import { validateSync } from '../../validation';
 
 class NodesClaim extends UnaryHandler<
   {
-    nodeManager: NodeManager;
     db: DB;
+    nodeManager: NodeManager;
   },
   ClientRPCRequestParams<ClaimNodeMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -23,8 +23,8 @@ class NodesClaim extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<ClaimNodeMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { nodeManager, db } = this.container;
-
+    const { db, nodeManager }: { db: DB; nodeManager: NodeManager } =
+      this.container;
     const {
       nodeId,
     }: {
@@ -45,9 +45,7 @@ class NodesClaim extends UnaryHandler<
       // if there is no permission then we get an error
       await nodeManager.claimNode(nodeId, tran);
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/NodesFind.ts
+++ b/src/client/handlers/NodesFind.ts
@@ -26,8 +26,7 @@ class NodesFind extends UnaryHandler<
     _meta,
     ctx: ContextTimed,
   ): Promise<ClientRPCResponseResult<NodesFindMessage>> => {
-    const { nodeManager } = this.container;
-
+    const { nodeManager }: { nodeManager: NodeManager } = this.container;
     const {
       nodeId,
     }: {

--- a/src/client/handlers/NodesGetAll.ts
+++ b/src/client/handlers/NodesGetAll.ts
@@ -3,7 +3,6 @@ import type {
   ClientRPCResponseResult,
   NodesGetMessage,
 } from '../types';
-import type KeyRing from '../../keys/KeyRing';
 import type NodeGraph from '../../nodes/NodeGraph';
 import { ServerHandler } from '@matrixai/rpc';
 import * as nodesUtils from '../../nodes/utils';
@@ -11,12 +10,11 @@ import * as nodesUtils from '../../nodes/utils';
 class NodesGetAll extends ServerHandler<
   {
     nodeGraph: NodeGraph;
-    keyRing: KeyRing;
   },
   ClientRPCRequestParams,
   ClientRPCResponseResult<NodesGetMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     _input,
     _cancel,
     _meta,
@@ -38,7 +36,7 @@ class NodesGetAll extends ServerHandler<
         };
       }
     }
-  }
+  };
 }
 
 export default NodesGetAll;

--- a/src/client/handlers/NodesListConnections.ts
+++ b/src/client/handlers/NodesListConnections.ts
@@ -14,13 +14,15 @@ class NodesListConnections extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<NodeConnectionMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     _input,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodeConnectionMessage>> {
-    const { nodeConnectionManager } = this.container;
+    const {
+      nodeConnectionManager,
+    }: { nodeConnectionManager: NodeConnectionManager } = this.container;
     const connections = nodeConnectionManager.listConnections();
     for (const connection of connections) {
       if (ctx.signal.aborted) throw ctx.signal.reason;
@@ -33,7 +35,7 @@ class NodesListConnections extends ServerHandler<
         usageCount: connection.usageCount,
       };
     }
-  }
+  };
 }
 
 export default NodesListConnections;

--- a/src/client/handlers/NodesPing.ts
+++ b/src/client/handlers/NodesPing.ts
@@ -21,7 +21,7 @@ class NodesPing extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { nodeManager } = this.container;
+    const { nodeManager }: { nodeManager: NodeManager } = this.container;
     const {
       nodeId,
     }: {
@@ -38,9 +38,7 @@ class NodesPing extends UnaryHandler<
       },
     );
     const result = await nodeManager.pingNode(nodeId);
-    return {
-      success: result != null,
-    };
+    return { type: 'success', success: result != null };
   };
 }
 

--- a/src/client/handlers/NotificationsInboxClear.ts
+++ b/src/client/handlers/NotificationsInboxClear.ts
@@ -12,7 +12,10 @@ class NotificationsInboxClear extends UnaryHandler<
   ClientRPCResponseResult
 > {
   public handle = async (): Promise<ClientRPCResponseResult> => {
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     await db.withTransactionF((tran) =>
       notificationsManager.clearInboxNotifications(tran),
     );

--- a/src/client/handlers/NotificationsInboxRead.ts
+++ b/src/client/handlers/NotificationsInboxRead.ts
@@ -25,7 +25,10 @@ class NotificationsInboxRead extends ServerHandler<
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NotificationInboxMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     const { seek, seekEnd, unread, order, limit } = input;
 
     let seek_: NotificationId | number | undefined;

--- a/src/client/handlers/NotificationsInboxRemove.ts
+++ b/src/client/handlers/NotificationsInboxRemove.ts
@@ -20,7 +20,10 @@ class NotificationsInboxRemove extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NotificationRemoveMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     const notificationId = notificationsUtils.decodeNotificationId(
       input.notificationIdEncoded,
     );

--- a/src/client/handlers/NotificationsOutboxClear.ts
+++ b/src/client/handlers/NotificationsOutboxClear.ts
@@ -12,7 +12,10 @@ class NotificationsOutboxClear extends UnaryHandler<
   ClientRPCResponseResult
 > {
   public handle = async (): Promise<ClientRPCResponseResult> => {
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     await db.withTransactionF((tran) =>
       notificationsManager.clearOutboxNotifications(tran),
     );

--- a/src/client/handlers/NotificationsOutboxRead.ts
+++ b/src/client/handlers/NotificationsOutboxRead.ts
@@ -25,7 +25,10 @@ class NotificationsOutboxRead extends ServerHandler<
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NotificationOutboxMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     const { seek, seekEnd, order, limit } = input;
 
     let seek_: NotificationId | number | undefined;

--- a/src/client/handlers/NotificationsOutboxRemove.ts
+++ b/src/client/handlers/NotificationsOutboxRemove.ts
@@ -20,7 +20,10 @@ class NotificationsOutboxRemove extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NotificationRemoveMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { db, notificationsManager } = this.container;
+    const {
+      db,
+      notificationsManager,
+    }: { db: DB; notificationsManager: NotificationsManager } = this.container;
     const notificationId = notificationsUtils.decodeNotificationId(
       input.notificationIdEncoded,
     );

--- a/src/client/handlers/NotificationsSend.ts
+++ b/src/client/handlers/NotificationsSend.ts
@@ -21,7 +21,9 @@ class NotificationsSend extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<NotificationSendMessage>,
   ): Promise<ClientRPCResponseResult> => {
-    const { notificationsManager } = this.container;
+    const {
+      notificationsManager,
+    }: { notificationsManager: NotificationsManager } = this.container;
     const {
       nodeId,
     }: {

--- a/src/client/handlers/VaultsClone.ts
+++ b/src/client/handlers/VaultsClone.ts
@@ -23,7 +23,8 @@ class VaultsClone extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<CloneMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     const {
       nodeId,
     }: {
@@ -43,9 +44,7 @@ class VaultsClone extends UnaryHandler<
     await db.withTransactionF(async (tran) => {
       await vaultManager.cloneVault(nodeId, input.nameOrId, tran);
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsCreate.ts
+++ b/src/client/handlers/VaultsCreate.ts
@@ -20,7 +20,8 @@ class VaultsCreate extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VaultNameMessage>,
   ): Promise<ClientRPCResponseResult<VaultIdMessage>> => {
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
 
     const vaultId = await db.withTransactionF((tran) =>
       vaultManager.createVault(input.vaultName, tran),

--- a/src/client/handlers/VaultsDelete.ts
+++ b/src/client/handlers/VaultsDelete.ts
@@ -22,7 +22,8 @@ class VaultsDelete extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId as VaultName,
@@ -35,9 +36,7 @@ class VaultsDelete extends UnaryHandler<
       }
       await vaultManager.destroyVault(vaultId, tran);
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsList.ts
+++ b/src/client/handlers/VaultsList.ts
@@ -16,14 +16,15 @@ class VaultsList extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<VaultListMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     _input,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultListMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     const vaults = await db.withTransactionF((tran) =>
       vaultManager.listVaults(tran),
     );
@@ -34,7 +35,7 @@ class VaultsList extends ServerHandler<
         vaultIdEncoded: vaultsUtils.encodeVaultId(vaultId),
       };
     }
-  }
+  };
 }
 
 export default VaultsList;

--- a/src/client/handlers/VaultsLog.ts
+++ b/src/client/handlers/VaultsLog.ts
@@ -19,14 +19,15 @@ class VaultsLog extends ServerHandler<
   ClientRPCRequestParams<VaultsLogMessage>,
   ClientRPCResponseResult<LogEntryMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<VaultsLogMessage>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<LogEntryMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     const log = await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId as VaultName,
@@ -55,7 +56,7 @@ class VaultsLog extends ServerHandler<
         message: entry.message,
       };
     }
-  }
+  };
 }
 
 export default VaultsLog;

--- a/src/client/handlers/VaultsPermissionGet.ts
+++ b/src/client/handlers/VaultsPermissionGet.ts
@@ -24,14 +24,18 @@ class VaultsPermissionGet extends ServerHandler<
   ClientRPCRequestParams<VaultIdentifierMessage>,
   ClientRPCResponseResult<VaultPermissionMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultPermissionMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { db, vaultManager, acl } = this.container;
+    const {
+      db,
+      vaultManager,
+      acl,
+    }: { db: DB; vaultManager: VaultManager; acl: ACL } = this.container;
     const [rawPermissions, vaultId] = await db.withTransactionF(
       async (tran) => {
         const vaultIdFromName = await vaultManager.getVaultId(
@@ -65,7 +69,7 @@ class VaultsPermissionGet extends ServerHandler<
         vaultPermissionList: actions,
       };
     }
-  }
+  };
 }
 
 export default VaultsPermissionGet;

--- a/src/client/handlers/VaultsPermissionSet.ts
+++ b/src/client/handlers/VaultsPermissionSet.ts
@@ -5,12 +5,12 @@ import type {
   PermissionSetMessage,
   SuccessMessage,
 } from '../types';
-import type VaultManager from '../../vaults/VaultManager';
-import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type ACL from '../../acl/ACL';
-import type NotificationsManager from '../../notifications/NotificationsManager';
 import type { VaultAction, VaultActions } from '../../vaults/types';
 import type { NodeId } from '../../ids';
+import type VaultManager from '../../vaults/VaultManager';
+import type NotificationsManager from '../../notifications/NotificationsManager';
+import type GestaltGraph from '../../gestalts/GestaltGraph';
 import { UnaryHandler } from '@matrixai/rpc';
 import * as ids from '../../ids';
 import * as vaultsUtils from '../../vaults/utils';
@@ -32,8 +32,19 @@ class VaultsPermissionSet extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PermissionSetMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { db, vaultManager, gestaltGraph, acl, notificationsManager } =
-      this.container;
+    const {
+      db,
+      vaultManager,
+      gestaltGraph,
+      acl,
+      notificationsManager,
+    }: {
+      db: DB;
+      vaultManager: VaultManager;
+      gestaltGraph: GestaltGraph;
+      acl: ACL;
+      notificationsManager: NotificationsManager;
+    } = this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -84,9 +95,7 @@ class VaultsPermissionSet extends UnaryHandler<
         },
       });
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsPermissionUnset.ts
+++ b/src/client/handlers/VaultsPermissionUnset.ts
@@ -30,7 +30,17 @@ class VaultsPermissionUnset extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<PermissionSetMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { db, vaultManager, gestaltGraph, acl } = this.container;
+    const {
+      db,
+      vaultManager,
+      gestaltGraph,
+      acl,
+    }: {
+      db: DB;
+      vaultManager: VaultManager;
+      gestaltGraph: GestaltGraph;
+      acl: ACL;
+    } = this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -83,9 +93,7 @@ class VaultsPermissionUnset extends UnaryHandler<
       }
     });
     // Formatting response
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsPull.ts
+++ b/src/client/handlers/VaultsPull.ts
@@ -26,7 +26,8 @@ class VaultsPull extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VaultsPullMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     let pullVaultId;
     pullVaultId = vaultsUtils.decodeVaultId(input.pullVault);
     pullVaultId = pullVaultId ?? input.pullVault;
@@ -62,9 +63,7 @@ class VaultsPull extends UnaryHandler<
         tran,
       });
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsRename.ts
+++ b/src/client/handlers/VaultsRename.ts
@@ -12,8 +12,8 @@ import * as vaultsErrors from '../../vaults/errors';
 
 class VaultsRename extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<VaultsRenameMessage>,
   ClientRPCResponseResult<VaultIdMessage>
@@ -21,7 +21,8 @@ class VaultsRename extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VaultsRenameMessage>,
   ): Promise<ClientRPCResponseResult<VaultIdMessage>> => {
-    const { db, vaultManager } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     return await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,

--- a/src/client/handlers/VaultsScan.ts
+++ b/src/client/handlers/VaultsScan.ts
@@ -18,14 +18,14 @@ class VaultsScan extends ServerHandler<
   ClientRPCRequestParams<NodeIdMessage>,
   ClientRPCResponseResult<VaultsScanMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<NodeIdMessage>,
     _cancel,
     _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultsScanMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { vaultManager } = this.container;
+    const { vaultManager }: { vaultManager: VaultManager } = this.container;
     const {
       nodeId,
     }: {
@@ -53,7 +53,7 @@ class VaultsScan extends ServerHandler<
         permissions: vaultPermissions,
       };
     }
-  }
+  };
 }
 
 export default VaultsScan;

--- a/src/client/handlers/VaultsSecretsEnv.ts
+++ b/src/client/handlers/VaultsSecretsEnv.ts
@@ -12,8 +12,8 @@ import * as vaultsErrors from '../../vaults/errors';
 
 class VaultsSecretsList extends DuplexHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
   ClientRPCResponseResult<SecretContentMessage>
@@ -27,7 +27,7 @@ class VaultsSecretsList extends DuplexHandler<
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<SecretContentMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { vaultManager, db }: { vaultManager: VaultManager; db: DB } =
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;
 
     return yield* db.withTransactionG(async function* (tran): AsyncGenerator<

--- a/src/client/handlers/VaultsSecretsGet.ts
+++ b/src/client/handlers/VaultsSecretsGet.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsGet extends DuplexHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
   ClientRPCResponseResult<ContentWithErrorMessage>
@@ -26,7 +26,8 @@ class VaultsSecretsGet extends DuplexHandler<
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<ContentWithErrorMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     yield* db.withTransactionG(async function* (tran): AsyncGenerator<
       ClientRPCResponseResult<ContentWithErrorMessage>
     > {

--- a/src/client/handlers/VaultsSecretsList.ts
+++ b/src/client/handlers/VaultsSecretsList.ts
@@ -13,17 +13,17 @@ import * as vaultsErrors from '../../vaults/errors';
 
 class VaultsSecretsList extends ServerHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
   ClientRPCResponseResult<SecretFilesMessage>
 > {
-  public async *handle(
+  public handle = async function* (
     input: ClientRPCRequestParams<SecretIdentifierMessage>,
-    _cancel: any,
   ): AsyncGenerator<ClientRPCResponseResult<SecretFilesMessage>, void, void> {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     const vaultId = await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -65,7 +65,7 @@ class VaultsSecretsList extends ServerHandler<
         }
       });
     });
-  }
+  };
 }
 
 export default VaultsSecretsList;

--- a/src/client/handlers/VaultsSecretsMkdir.ts
+++ b/src/client/handlers/VaultsSecretsMkdir.ts
@@ -2,50 +2,61 @@ import type { DB } from '@matrixai/db';
 import type {
   ClientRPCRequestParams,
   ClientRPCResponseResult,
-  SecretMkdirMessage,
-  SuccessMessage,
+  SecretDirMessage,
+  SuccessOrErrorMessage,
 } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
-import { UnaryHandler } from '@matrixai/rpc';
+import type { POJO } from '../../types';
+import { DuplexHandler } from '@matrixai/rpc';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
 import * as vaultOps from '../../vaults/VaultOps';
 
-class VaultsSecretsMkdir extends UnaryHandler<
+class VaultsSecretsMkdir extends DuplexHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
-  ClientRPCRequestParams<SecretMkdirMessage>,
-  ClientRPCResponseResult<SuccessMessage>
+  ClientRPCRequestParams<SecretDirMessage>,
+  ClientRPCResponseResult<SuccessOrErrorMessage>
 > {
-  public handle = async (
-    input: ClientRPCRequestParams<SecretMkdirMessage>,
-  ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db } = this.container;
-    await db.withTransactionF(async (tran) => {
-      const vaultIdFromName = await vaultManager.getVaultId(
-        input.nameOrId,
-        tran,
-      );
-      const vaultId =
-        vaultIdFromName ?? vaultsUtils.decodeVaultId(input.nameOrId);
-      if (vaultId == null) {
-        throw new vaultsErrors.ErrorVaultsVaultUndefined();
-      }
-      await vaultManager.withVaults(
-        [vaultId],
-        async (vault) => {
-          await vaultOps.mkdir(vault, input.dirName, {
-            recursive: input.recursive,
-          });
-        },
-        tran,
-      );
-    });
-    return {
-      success: true,
-    };
+  public handle = async function* (
+    input: AsyncIterable<ClientRPCRequestParams<SecretDirMessage>>,
+  ): AsyncGenerator<ClientRPCResponseResult<SuccessOrErrorMessage>> {
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
+    let metadata: POJO;
+    yield* db.withTransactionG(
+      async function* (tran): AsyncGenerator<SuccessOrErrorMessage> {
+        for await (const secretDirMessage of input) {
+          // Unpack input
+          if (metadata == null) metadata = secretDirMessage.metadata ?? {};
+          const nameOrId = secretDirMessage.nameOrId;
+          const dirName = secretDirMessage.dirName;
+          // Get vaultId
+          const vaultIdFromName = await vaultManager.getVaultId(nameOrId, tran);
+          const vaultId =
+            vaultIdFromName ?? vaultsUtils.decodeVaultId(nameOrId);
+          if (vaultId == null) {
+            throw new vaultsErrors.ErrorVaultsVaultUndefined();
+          }
+          // Write directories. This doesn't need to be grouped by vault names,
+          // as no commit is created for empty directories anyways. The
+          // vaultOps.mkdir() method also returns an object of type
+          // SuccessOrErrorMessage. As such, we can return the result without
+          // doing any type conversion or extra processing.
+          yield await vaultManager.withVaults(
+            [vaultId],
+            async (vault) => {
+              return await vaultOps.mkdir(vault, dirName, {
+                recursive: metadata?.options?.recursive,
+              });
+            },
+            tran,
+          );
+        }
+      },
+    );
   };
 }
 

--- a/src/client/handlers/VaultsSecretsNew.ts
+++ b/src/client/handlers/VaultsSecretsNew.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsNew extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretContentMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -22,7 +22,8 @@ class VaultsSecretsNew extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SecretContentMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -42,9 +43,7 @@ class VaultsSecretsNew extends UnaryHandler<
         tran,
       );
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsSecretsNewDir.ts
+++ b/src/client/handlers/VaultsSecretsNewDir.ts
@@ -14,9 +14,9 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsNewDir extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
     fs: FileSystem;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretDirMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -24,7 +24,11 @@ class VaultsSecretsNewDir extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SecretDirMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db, fs } = this.container;
+    const {
+      db,
+      fs,
+      vaultManager,
+    }: { db: DB; fs: FileSystem; vaultManager: VaultManager } = this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -43,9 +47,7 @@ class VaultsSecretsNewDir extends UnaryHandler<
         tran,
       );
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsSecretsRemove.ts
+++ b/src/client/handlers/VaultsSecretsRemove.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsRemove extends ClientHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -22,7 +22,8 @@ class VaultsSecretsRemove extends ClientHandler<
   public handle = async (
     input: AsyncIterable<ClientRPCRequestParams<SecretIdentifierMessage>>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     // Create a record of secrets to be removed, grouped by vault names
     const vaultGroups: Record<string, Array<string>> = {};
     const secretNames: Array<[string, string]> = [];
@@ -58,7 +59,7 @@ class VaultsSecretsRemove extends ClientHandler<
       }
     });
 
-    return { success: true };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsSecretsRename.ts
+++ b/src/client/handlers/VaultsSecretsRename.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsRename extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretRenameMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -22,7 +22,8 @@ class VaultsSecretsRename extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SecretRenameMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -45,9 +46,7 @@ class VaultsSecretsRename extends UnaryHandler<
         tran,
       );
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsSecretsStat.ts
+++ b/src/client/handlers/VaultsSecretsStat.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsStat extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretIdentifierMessage>,
   ClientRPCResponseResult<SecretStatMessage>
@@ -22,7 +22,8 @@ class VaultsSecretsStat extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SecretIdentifierMessage>,
   ): Promise<ClientRPCResponseResult<SecretStatMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     return await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,

--- a/src/client/handlers/VaultsSecretsWriteFile.ts
+++ b/src/client/handlers/VaultsSecretsWriteFile.ts
@@ -13,8 +13,8 @@ import * as vaultOps from '../../vaults/VaultOps';
 
 class VaultsSecretsWriteFile extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<SecretContentMessage>,
   ClientRPCResponseResult<SuccessMessage>
@@ -22,7 +22,8 @@ class VaultsSecretsWriteFile extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<SecretContentMessage>,
   ): Promise<ClientRPCResponseResult<SuccessMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,
@@ -42,9 +43,7 @@ class VaultsSecretsWriteFile extends UnaryHandler<
         tran,
       );
     });
-    return {
-      success: true,
-    };
+    return { type: 'success', success: true };
   };
 }
 

--- a/src/client/handlers/VaultsVersion.ts
+++ b/src/client/handlers/VaultsVersion.ts
@@ -12,8 +12,8 @@ import * as vaultsErrors from '../../vaults/errors';
 
 class VaultsVersion extends UnaryHandler<
   {
-    vaultManager: VaultManager;
     db: DB;
+    vaultManager: VaultManager;
   },
   ClientRPCRequestParams<VaultsVersionMessage>,
   ClientRPCResponseResult<VaultsLatestVersionMessage>
@@ -21,7 +21,8 @@ class VaultsVersion extends UnaryHandler<
   public handle = async (
     input: ClientRPCRequestParams<VaultsVersionMessage>,
   ): Promise<ClientRPCResponseResult<VaultsLatestVersionMessage>> => {
-    const { vaultManager, db } = this.container;
+    const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
+      this.container;
     return await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(
         input.nameOrId,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -201,8 +201,18 @@ type SignatureMessage = {
 type VerifySignatureMessage = PublicKeyMessage & DataMessage & SignatureMessage;
 
 type SuccessMessage = {
+  type: 'success';
   success: boolean;
 };
+
+type ErrorMessage = {
+  type: 'error';
+  code: string;
+  reason?: string;
+  data?: JSONObject;
+};
+
+type SuccessOrErrorMessage = SuccessMessage | ErrorMessage;
 
 // Notifications messages
 
@@ -317,11 +327,6 @@ type ContentWithErrorMessage = ContentMessage & {
 
 type SecretContentMessage = SecretIdentifierMessage & ContentMessage;
 
-type SecretMkdirMessage = VaultIdentifierMessage & {
-  dirName: string;
-  recursive: boolean;
-};
-
 type SecretDirMessage = VaultIdentifierMessage & {
   dirName: string;
 };
@@ -398,6 +403,8 @@ export type {
   NodesGetMessage,
   NodesAddMessage,
   SuccessMessage,
+  ErrorMessage,
+  SuccessOrErrorMessage,
   NotificationInboxMessage,
   NotificationOutboxMessage,
   NotificationReadMessage,
@@ -423,7 +430,6 @@ export type {
   ContentMessage,
   ContentWithErrorMessage,
   SecretContentMessage,
-  SecretMkdirMessage,
   SecretDirMessage,
   SecretRenameMessage,
   SecretFilesMessage,


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

Following the behaviour of UNIX's `mkdir`, the behaviour of `VaultsSecretsMkdir` is being tweaked to function more seamlessly.

The `VaultsSecretsMkdir` handler now supports creating multiple directories in multiple vaults, all in a single commit message. If a directory fails to be created, the whole command will no longer fail, merely returning an error.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to <b>[Polykey-CLI#246](https://github.com/MatrixAI/Polykey-CLI/issues/246)</b>
* REF ENG-359

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Make new vaultOps function for making directories without returning on error
- [x] 2. Update `VaultsSecretsMkdir` handler to make multiple directories across multiple vaults in a single vaults log commit
- [x] ~~3. Allow serialisation and deserialisation of errors~~ We are returning plain error strings. We won't be serialising and deserialising errors.
- [x] 4. Merge behaviour of `vaultOps.makeDirectories` into `vaultOps.mkdir`
- [x] 5. Update tests for `vaultOps.mkdir`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
