### PR TITLE
Adding better error messaging when stringifying errors in logging

### DIFF
--- a/src/ErrorPolykey.ts
+++ b/src/ErrorPolykey.ts
@@ -39,6 +39,13 @@ class ErrorPolykey<T> extends AbstractError<T> {
     json.data.exitCode = this.exitCode;
     return json;
   }
+
+  public toString(): string {
+    const messageString =
+      this.message.length > 0 ? `("${this.message}")` : '()';
+    const chainString = this.cause != null ? `>${String(this.cause)}` : '';
+    return `${this.name}${messageString}${chainString}`;
+  }
 }
 
 export default ErrorPolykey;

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -803,7 +803,9 @@ class PolykeyAgent {
       const setNodeProms = new Array<Promise<void>>();
       for (const nodeIdEncoded in optionsDefaulted.seedNodes) {
         const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
-        if (nodeId == null) utils.never();
+        if (nodeId == null) {
+          utils.never(`failed to decode NodeId "${nodeIdEncoded}"`);
+        }
         const setNodeProm = this.nodeManager.setNode(
           nodeId,
           optionsDefaulted.seedNodes[nodeIdEncoded],
@@ -825,7 +827,9 @@ class PolykeyAgent {
         const initialNodes = seedNodeEntries.map(
           ([nodeIdEncoded, nodeAddress]) => {
             const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
-            if (nodeId == null) utils.never('nodeId should be defined');
+            if (nodeId == null) {
+              utils.never(`failed to decode NodeId "${nodeIdEncoded}"`);
+            }
             return [nodeId, nodeAddress] as [NodeId, NodeAddress];
           },
         );

--- a/src/client/authenticationMiddleware.ts
+++ b/src/client/authenticationMiddleware.ts
@@ -105,7 +105,9 @@ function authenticationMiddlewareClient(
       >({
         transform: async (chunk, controller) => {
           if (forwardFirst) {
-            if (chunk.params == null) utils.never();
+            if (chunk.params == null) {
+              utils.never('chunk.params must be defined');
+            }
             if (chunk.params.metadata?.authorization == null) {
               const token = await session.readToken();
               if (token != null) {

--- a/src/client/handlers/IdentitiesAuthenticate.ts
+++ b/src/client/handlers/IdentitiesAuthenticate.ts
@@ -50,7 +50,7 @@ class IdentitiesAuthenticate extends ServerHandler<
     const authFlow = provider.authenticate(ctx.timer.getTimeout());
     let authFlowResult = await authFlow.next();
     if (authFlowResult.done) {
-      never();
+      never('authFlow signalled done too soon');
     }
     if (ctx.signal.aborted) throw ctx.signal.reason;
     yield {
@@ -61,7 +61,7 @@ class IdentitiesAuthenticate extends ServerHandler<
     };
     authFlowResult = await authFlow.next();
     if (!authFlowResult.done) {
-      never();
+      never('authFlow did not signal done when expected');
     }
     if (ctx.signal.aborted) throw ctx.signal.reason;
     yield {

--- a/src/client/handlers/KeysDecrypt.ts
+++ b/src/client/handlers/KeysDecrypt.ts
@@ -19,7 +19,7 @@ class KeysDecrypt extends UnaryHandler<
   ): Promise<ClientRPCResponseResult<DataMessage>> => {
     const { keyRing }: { keyRing: KeyRing } = this.container;
     const data = keyRing.decrypt(Buffer.from(input.data, 'binary'));
-    if (data == null) never();
+    if (data == null) never('failed to decrypt DataMessage');
     return {
       data: data.toString('binary'),
     };

--- a/src/client/handlers/KeysEncrypt.ts
+++ b/src/client/handlers/KeysEncrypt.ts
@@ -27,7 +27,7 @@ class KeysEncrypt extends UnaryHandler<
     try {
       const jwk = input.publicKeyJwk;
       publicKey = keysUtils.publicKeyFromJWK(jwk);
-      if (publicKey == null) never();
+      if (publicKey == null) never('failed to get public key from JWK');
     } catch (e) {
       throw new keysErrors.ErrorPublicKeyParse(undefined, { cause: e });
     }

--- a/src/client/handlers/KeysVerify.ts
+++ b/src/client/handlers/KeysVerify.ts
@@ -26,7 +26,7 @@ class KeysVerify extends UnaryHandler<
     try {
       const jwk = input.publicKeyJwk;
       publicKey = keysUtils.publicKeyFromJWK(jwk);
-      if (publicKey == null) never();
+      if (publicKey == null) never('failed to get public key from JWK');
     } catch (e) {
       throw new keysErrors.ErrorPublicKeyParse(undefined, { cause: e });
     }

--- a/src/gestalts/GestaltGraph.ts
+++ b/src/gestalts/GestaltGraph.ts
@@ -298,7 +298,7 @@ class GestaltGraph {
           break;
         case 'identity':
         default:
-          never();
+          never(`type must be either "node" or "identity" got "${type}"`);
       }
     }
     // 2. remove the node information.
@@ -318,7 +318,7 @@ class GestaltGraph {
       case 'identity':
         return this.setIdentity(info, tran);
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -335,7 +335,7 @@ class GestaltGraph {
       case 'identity':
         return this.unsetIdentity(id, tran);
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -468,7 +468,9 @@ class GestaltGraph {
         never('lastProcessedTime should be valid here');
       }
       const gestaltId = gestaltsUtils.decodeGestaltId(gestaltIdEncoded);
-      if (gestaltId == null) never('GestaltId should be valid here');
+      if (gestaltId == null) {
+        never(`failed to decode GestaltId "${gestaltIdEncoded}"`);
+      }
       yield [gestaltId, lastProcessedTime];
     }
   }
@@ -872,7 +874,9 @@ class GestaltGraph {
         tran,
       );
     } else {
-      never();
+      never(
+        `invalid claim between "${gestaltInfo1[0]}" and "${gestaltInfo2[0]}", must be a node to node or identity to node claim`,
+      );
     }
   }
 
@@ -1065,7 +1069,9 @@ class GestaltGraph {
         tran,
       );
     } else {
-      never();
+      never(
+        `invalid link between "${type1}" and "${type2}", must be node to node or node to identity`,
+      );
     }
   }
 
@@ -1104,7 +1110,7 @@ class GestaltGraph {
         return perm.gestalt;
       }
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -1143,7 +1149,7 @@ class GestaltGraph {
         return;
       }
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -1183,7 +1189,7 @@ class GestaltGraph {
         return;
       }
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -1231,7 +1237,7 @@ class GestaltGraph {
       case 'identity':
         return await this.getGestaltByIdentity(id, tran);
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 
@@ -1335,7 +1341,7 @@ class GestaltGraph {
         return ['identity', gestaltIdentityInfo];
       }
       default:
-        never();
+        never(`type must be either "node" or "identity" got "${type}"`);
     }
   }
 

--- a/src/git/http.ts
+++ b/src/git/http.ts
@@ -324,9 +324,7 @@ async function parsePackRequest(
         case 'done':
           return [wants, haves, capabilities];
         default:
-          utils.never(
-            `Type should be either 'want' or 'have', found '${type}'`,
-          );
+          utils.never(`Type should be either "want" or "have", got "${type}"`);
       }
     }
   }

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -248,7 +248,9 @@ async function listObjectsAll({
   const objectSet: Set<string> = new Set();
   const objectDirs = await fs.promises.readdir(objectsDirPath);
   for (const objectDir of objectDirs) {
-    if (typeof objectDir !== 'string') utils.never();
+    if (typeof objectDir !== 'string') {
+      utils.never('objectDir should be a string');
+    }
     if (excludedDirs.includes(objectDir)) continue;
     const objectIds = await fs.promises.readdir(
       path.join(objectsDirPath, objectDir),

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -279,7 +279,7 @@ class NodeConnection {
     }
     const quicConnection = quicClient.connection;
     const throwFunction = () =>
-      never('We should never get connections before setting up handling');
+      never('we should never get connections before setting up handling');
     quicConnection.addEventListener(
       quicEvents.EventQUICConnectionStream.name,
       throwFunction,
@@ -293,7 +293,9 @@ class NodeConnection {
       toError: networkUtils.toError,
       logger: logger.getChild(RPCClient.name),
     });
-    if (validatedNodeId == null) never();
+    if (validatedNodeId == null) {
+      never(`connection validated but no valid NodeId was returned`);
+    }
     // Obtaining remote node ID from certificate chain. It should always exist in the chain if validated.
     //  This may de different from the NodeId we validated it as if it renewed at some point.
     const connection = quicClient.connection;

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -407,9 +407,9 @@ class NodeConnectionManager {
 
     const quicSocket = new QUICSocket({
       resolveHostname: () => {
-        // `NodeConnectionManager` must resolve all hostnames before it reaches
-        // `QUICSocket`.
-        utils.never();
+        utils.never(
+          '"NodeConnectionManager" must resolve all hostnames before it reaches "QUICSocket"',
+        );
       },
       logger: this.logger.getChild(QUICSocket.name),
     });
@@ -695,7 +695,7 @@ class NodeConnectionManager {
     const [release, conn] = await acquire();
     let caughtError;
     try {
-      if (conn == null) utils.never();
+      if (conn == null) utils.never('NodeConnection should exist');
       return yield* g(conn);
     } catch (e) {
       caughtError = e;
@@ -1042,12 +1042,16 @@ class NodeConnectionManager {
       const cert = keysUtils.certFromPEM(
         quicUtils.derToPEM(der) as CertificatePEM,
       );
-      if (cert == null) utils.never();
+      if (cert == null) {
+        utils.never('failed to parse certificate from connection cert chain');
+      }
       return cert;
     });
-    if (certChain == null) utils.never();
+    if (certChain.length === 0) {
+      utils.never('there must be at least 1 certificate in the chain');
+    }
     const nodeId = keysUtils.certNodeId(certChain[0]);
-    if (nodeId == null) utils.never();
+    if (nodeId == null) utils.never('failed to get NodeId from certificate');
     const nodeConnectionNew = NodeConnection.createNodeConnectionReverse({
       nodeId,
       certChain,

--- a/src/nodes/NodeGraph.ts
+++ b/src/nodes/NodeGraph.ts
@@ -659,7 +659,9 @@ class NodeGraph {
           IdInternal.fromBuffer<NodeId>(nodeIdBuffer),
           tran,
         );
-        if (nodeContact == null) utils.never();
+        if (nodeContact == null) {
+          utils.never('failed to get expected NodeContact');
+        }
         bucket.push([nodeId, nodeContact]);
       }
     }

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -240,7 +240,9 @@ class NodeManager {
           );
         }
         const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
-        if (nodeId == null) utils.never();
+        if (nodeId == null) {
+          utils.never(`failed to decode NodeId "${nodeIdEncoded}"`);
+        }
         return this.nodeConnectionManager.createConnectionMultiple(
           [nodeId],
           resolvedHosts,
@@ -541,7 +543,7 @@ class NodeManager {
     const [release, conn] = await acquire();
     let caughtError;
     try {
-      if (conn == null) utils.never();
+      if (conn == null) utils.never('NodeConnection should exist');
       return yield* g(conn);
     } catch (e) {
       caughtError = e;
@@ -1106,7 +1108,7 @@ class NodeManager {
         for await (const result of resultStream) {
           const nodeIdNew = nodesUtils.decodeNodeId(result.nodeId);
           if (nodeIdNew == null) {
-            utils.never('failed to decode nodeId');
+            utils.never(`failed to decode NodeId "${result.nodeId}"`);
           }
           nodeConnectionsQueue.queueNodeSignal(nodeIdNew, nodeId);
         }
@@ -1118,7 +1120,9 @@ class NodeManager {
           });
         for await (const { nodeIdEncoded, nodeContact } of resultStream) {
           const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
-          if (nodeId == null) utils.never();
+          if (nodeId == null) {
+            utils.never(`failed to decode NodeId "${nodeIdEncoded}"`);
+          }
           nodeConnectionsQueue.queueNodeDirect(nodeId, nodeContact);
         }
       })();
@@ -1826,7 +1830,7 @@ class NodeManager {
       this.nodeGraph.nodeBucketLimit,
       tran,
     );
-    if (bucket == null) utils.never();
+    if (bucket == null) utils.never('bucket should exist');
     let removedNodes = 0;
     const unsetLock = new Lock();
     const pendingPromises: Array<Promise<void>> = [];
@@ -2156,7 +2160,7 @@ class NodeManager {
         priority: 0,
       });
     }
-    if (foundTask == null) utils.never();
+    if (foundTask == null) utils.never('task should exist');
     return foundTask;
   }
 

--- a/src/nodes/agent/handlers/VaultsGitInfoGet.ts
+++ b/src/nodes/agent/handlers/VaultsGitInfoGet.ts
@@ -33,15 +33,17 @@ class VaultsGitInfoGet extends RawHandler<{
     const [headerMessage, inputStream] = input;
     await inputStream.cancel();
     const params = headerMessage.params;
-    if (params == null || !utils.isObject(params)) utils.never();
+    if (params == null || !utils.isObject(params)) {
+      utils.never('params must be defined and an object');
+    }
     if (
       !('vaultNameOrId' in params) ||
       typeof params.vaultNameOrId != 'string'
     ) {
-      utils.never();
+      utils.never('vaultNameOrId must be defined and a string');
     }
     if (!('action' in params) || typeof params.action != 'string') {
-      utils.never();
+      utils.never('action must be defined and a string');
     }
     const vaultNameOrId = params.vaultNameOrId;
     const actionType = vaultsUtils.parseVaultAction(params.action);

--- a/src/nodes/agent/handlers/VaultsGitPackGet.ts
+++ b/src/nodes/agent/handlers/VaultsGitPackGet.ts
@@ -33,12 +33,14 @@ class VaultsGitPackGet extends RawHandler<{
     }
     const nodeIdEncoded = nodesUtils.encodeNodeId(requestingNodeId);
     const params = headerMessage.params;
-    if (params == null || !utils.isObject(params)) utils.never();
+    if (params == null || !utils.isObject(params)) {
+      utils.never('params must be defined and an object');
+    }
     if (!('nameOrId' in params) || typeof params.nameOrId != 'string') {
-      utils.never();
+      utils.never('nameOrId must be defined and a string');
     }
     if (!('vaultAction' in params) || typeof params.vaultAction != 'string') {
-      utils.never();
+      utils.never('vaultAction must be defined and a string');
     }
     const nameOrId = params.nameOrId;
     const actionType = vaultsUtils.parseVaultAction(params.vaultAction);

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -401,11 +401,13 @@ function parseRemoteCertsChain(remoteCertChain: Array<Uint8Array>) {
     const cert = keysUtils.certFromPEM(
       quicUtils.derToPEM(der) as CertificatePEM,
     );
-    if (cert == null) utils.never();
+    if (cert == null) {
+      utils.never('failed to parse certificate from cert chain');
+    }
     return cert;
   });
   const nodeId = keysUtils.certNodeId(certChain[0]);
-  if (nodeId == null) utils.never();
+  if (nodeId == null) utils.never('failed to get NodeId from certificate');
   return { nodeId, certChain };
 }
 

--- a/src/notifications/NotificationsManager.ts
+++ b/src/notifications/NotificationsManager.ts
@@ -497,7 +497,9 @@ class NotificationsManager {
 
     for await (const id of notificationIds) {
       const notification = await this.readOutboxNotificationById(id, tran);
-      if (notification == null) never();
+      if (notification == null) {
+        never('failed to read existing outbox notification');
+      }
       yield notification;
     }
   }
@@ -695,7 +697,9 @@ class NotificationsManager {
     });
     for await (const id of notificationIds) {
       const notification = await this.readInboxNotificationById(id, tran);
-      if (notification == null) never();
+      if (notification == null) {
+        never('failed to read existing inbox notification');
+      }
       yield notification;
     }
   }

--- a/src/notifications/errors.ts
+++ b/src/notifications/errors.ts
@@ -23,6 +23,11 @@ class ErrorNotificationsPermissionsNotFound<T> extends ErrorNotifications<T> {
   exitCode = sysexits.NOUSER;
 }
 
+class ErrorNotificationsNotificationRejected<T> extends ErrorNotifications<T> {
+  static description = 'Notification was rejected due to lack of permissions';
+  exitCode = sysexits.NOPERM;
+}
+
 class ErrorNotificationsDb<T> extends ErrorNotifications<T> {
   static description = 'Database consistency error';
   exitCode = sysexits.IOERR;
@@ -79,6 +84,7 @@ export {
   ErrorNotificationsNotRunning,
   ErrorNotificationsDestroyed,
   ErrorNotificationsPermissionsNotFound,
+  ErrorNotificationsNotificationRejected,
   ErrorNotificationsDb,
   ErrorNotificationsParse,
   ErrorNotificationsInvalidType,

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -58,7 +58,9 @@ async function verifyAndDecodeNotif(
   const token = Token.fromEncoded(JSON.parse(signedNotification));
   assertNotification(token.payload);
   const issuerNodeId = nodesUtils.decodeNodeId(token.payload.iss);
-  if (issuerNodeId == null) never();
+  if (issuerNodeId == null) {
+    never(`failed to decode issuer NodeId "${token.payload.iss}"`);
+  }
   const issuerPublicKey = keysUtils.publicKeyFromNodeId(issuerNodeId);
   if (!token.verifyWithPublicKey(issuerPublicKey)) {
     throw new notificationsErrors.ErrorNotificationsVerificationFailed();

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -819,16 +819,16 @@ class VaultInternal {
 
     const result = vaultsGitInfoGetStream.meta?.result;
     if (result == null || !utils.isObject(result)) {
-      utils.never('`result` must be a defined object');
+      utils.never('"result" must be a defined object');
     }
     if (!('vaultName' in result) || typeof result.vaultName !== 'string') {
-      utils.never('`vaultName` must be defined and a string');
+      utils.never('"vaultName" must be defined and a string');
     }
     if (
       !('vaultIdEncoded' in result) ||
       typeof result.vaultIdEncoded !== 'string'
     ) {
-      utils.never('`vaultIdEncoded` must be defined and a string');
+      utils.never('"vaultIdEncoded" must be defined and a string');
     }
     const vaultName = result.vaultName;
     const remoteVaultId = ids.parseVaultId(result.vaultIdEncoded);
@@ -850,30 +850,33 @@ class VaultInternal {
         headers: POJO;
         body: Array<Buffer>;
       }) {
-        if (method === 'GET') {
-          // Send back the GET request info response
-          return {
-            url: url,
-            method: method,
-            body: vaultsGitInfoGetStream.readable,
-            headers: headers,
-            statusCode: 200,
-            statusMessage: 'OK',
-          };
-        } else if (method === 'POST') {
-          const writer = vaultsGitPackGetStream.writable.getWriter();
-          await writer.write(body[0]);
-          await writer.close();
-          return {
-            url: url,
-            method: method,
-            body: vaultsGitPackGetStream.readable,
-            headers: headers,
-            statusCode: 200,
-            statusMessage: 'OK',
-          };
-        } else {
-          utils.never();
+        switch (method) {
+          case 'GET': {
+            // Send back the GET request info response
+            return {
+              url: url,
+              method: method,
+              body: vaultsGitInfoGetStream.readable,
+              headers: headers,
+              statusCode: 200,
+              statusMessage: 'OK',
+            };
+          }
+          case 'POST': {
+            const writer = vaultsGitPackGetStream.writable.getWriter();
+            await writer.write(body[0]);
+            await writer.close();
+            return {
+              url: url,
+              method: method,
+              body: vaultsGitPackGetStream.readable,
+              headers: headers,
+              statusCode: 200,
+              statusMessage: 'OK',
+            };
+          }
+          default:
+            utils.never(`method must be "GET" or "POST" got "${method}"`);
         }
       },
       vaultName,

--- a/tests/gestalts/utils.ts
+++ b/tests/gestalts/utils.ts
@@ -238,7 +238,7 @@ class UnsetVertexCommand implements GestaltGraphCommand {
     for (const vertex of vertices) {
       randomVertex2 = vertex;
     }
-    if (randomVertex2 == null) never();
+    if (randomVertex2 == null) never('randomVertex2 must be defined');
     const gestalt2ModelNew = getGestaltFromModel(
       model,
       gestaltsUtils.decodeGestaltId(randomVertex2)!,

--- a/tests/nodes/utils.test.ts
+++ b/tests/nodes/utils.test.ts
@@ -427,7 +427,9 @@ describe('nodes/utils', () => {
           cert.certChainPem.map((v) => wsUtils.pemToDER(v)),
         );
         expect(result.result).toBe('fail');
-        if (result.result !== 'fail') utils.never();
+        if (result.result !== 'fail') {
+          utils.never('result.result should be "fail"');
+        }
         expect(result.value).toBe(CryptoError.CertificateExpired);
       });
     });

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -345,8 +345,7 @@ describe('NotificationsManager', () => {
         pull: null,
       } as VaultActions,
     };
-
-    await testUtils.expectRemoteError(
+    await expect(
       notificationsManager
         .sendNotification({
           nodeId: receiver.keyRing.getNodeId(),
@@ -354,9 +353,10 @@ describe('NotificationsManager', () => {
           retries: 0,
         })
         .then((value) => value.sendP),
-      notificationsErrors.ErrorNotificationsPermissionsNotFound,
+    ).rejects.toThrow(
+      notificationsErrors.ErrorNotificationsNotificationRejected,
     );
-    await testUtils.expectRemoteError(
+    await expect(
       notificationsManager
         .sendNotification({
           nodeId: receiver.keyRing.getNodeId(),
@@ -364,9 +364,10 @@ describe('NotificationsManager', () => {
           retries: 0,
         })
         .then((value) => value.sendP),
-      notificationsErrors.ErrorNotificationsPermissionsNotFound,
+    ).rejects.toThrow(
+      notificationsErrors.ErrorNotificationsNotificationRejected,
     );
-    await testUtils.expectRemoteError(
+    await expect(
       notificationsManager
         .sendNotification({
           nodeId: receiver.keyRing.getNodeId(),
@@ -374,7 +375,8 @@ describe('NotificationsManager', () => {
           retries: 0,
         })
         .then((value) => value.sendP),
-      notificationsErrors.ErrorNotificationsPermissionsNotFound,
+    ).rejects.toThrow(
+      notificationsErrors.ErrorNotificationsNotificationRejected,
     );
     await expect(
       notificationsManager

--- a/tests/tasks/TaskManager.test.ts
+++ b/tests/tasks/TaskManager.test.ts
@@ -927,7 +927,7 @@ describe(TaskManager.name, () => {
 
     // Task should be updated
     const oldTask = await taskManager.getTask(task1.id);
-    if (oldTask == null) utils.never();
+    if (oldTask == null) utils.never('failed to get old task');
     expect(oldTask.id.equals(task1.id)).toBeTrue();
     expect(oldTask.handlerId).toEqual(handlerId2);
     expect(oldTask.delay).toBe(0);
@@ -983,7 +983,7 @@ describe(TaskManager.name, () => {
     ).rejects.toThrow(tasksErrors.ErrorTaskRunning);
     // Task has not been updated
     const oldTask = await taskManager.getTask(task1.id);
-    if (oldTask == null) utils.never();
+    if (oldTask == null) utils.never('failed to get old task');
     expect(oldTask.delay).toBe(0);
     expect(oldTask.parameters).toEqual([]);
     await taskManager.stop();
@@ -1019,7 +1019,7 @@ describe(TaskManager.name, () => {
     });
     // Task should be updated
     const newTask = await taskManager.getTask(task1.id);
-    if (newTask == null) utils.never();
+    if (newTask == null) utils.never('failed to get new task');
     expect(newTask.delay).toBe(0);
     expect(newTask.parameters).toEqual([1]);
     // Task should resolve with new parameter


### PR DESCRIPTION
### Description

This PR cleans up some error messaging in hope that it will make further error logging more clear for debug.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey/issues/824
* REF ENG-427

### Tasks

- [X] 1. Add better description and include cause details when stringifying errors.
- [X] 2. Add descriptions to all usage of `utils.never()`.
- [X] 3. Add a better error to send notification when sending is rejected by peer for lack of trust.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
