### PR TITLE
Fix undefined behaviour for `GestaltId` when starting agent

### DIFF
--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -211,7 +211,7 @@ class Discovery {
       Date.now() - this.rediscoverVertexThresholdTime,
     );
     await this.taskManager.scheduleTask({
-      handlerId: this.discoverVertexHandlerId,
+      handlerId: this.checkRediscoveryHandlerId,
       path: [this.constructor.name, this.checkRediscoveryHandlerId],
       lazy: true,
       delay: this.rediscoverCheckIntervalTime,
@@ -285,7 +285,7 @@ class Discovery {
     );
     // Start up rediscovery task
     await this.taskManager.scheduleTask({
-      handlerId: this.discoverVertexHandlerId,
+      handlerId: this.checkRediscoveryHandlerId,
       path: [this.constructor.name, this.checkRediscoveryHandlerId],
       lazy: true,
       delay: this.rediscoverCheckIntervalTime,


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
When starting the agent after approximately 1 hour, an error is thrown like such:

```
WARN:polykey.PolykeyAgent.task v0ppdq4uibpo01417n072jft4io:Failed - Reason: ErrorUtilsUndefinedBehaviour("failed to decode vertex GestaltId "undefined"")
```

This is caused due to a minor typo in the discovery domain. This has been resolved in this PR, and similar messages should no longer happen.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #797 (REF ENG-400)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Fix the undefined behaviour error

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
