### PR TITLE
Allow vault `efs` resource acquisition to operate on multiple vaults in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@matrixai/mdns": "^1.2.6",
         "@matrixai/quic": "^1.3.1",
         "@matrixai/resources": "^1.1.5",
-        "@matrixai/rpc": "^0.6.0",
+        "@matrixai/rpc": "^0.6.2",
         "@matrixai/timer": "^1.1.3",
         "@matrixai/workers": "^1.3.7",
         "@matrixai/ws": "^1.1.7",
@@ -1696,9 +1696,9 @@
       "integrity": "sha512-m/DEZEe3wHqWEPTyoBtzFF6U9vWYhEnQtGgwvqiAlTxTM0rk96UBpWjDZCTF/vYG11ZlmlQFtg5H+zGgbjaB3Q=="
     },
     "node_modules/@matrixai/rpc": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/rpc/-/rpc-0.6.0.tgz",
-      "integrity": "sha512-ENjJO2h7CmPLaHhObHs2nvpv98YZPxa79/jf+TqEPEfbhE1BkNCys9pXDE/CYDP9vxb4seS39WkR9cNivQU50A==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@matrixai/rpc/-/rpc-0.6.3.tgz",
+      "integrity": "sha512-jLR+SpAnv6NR2xRtXGBnyBGipLBv/Nnn/8b6OYx2loyNT4WHoxtqh51U6QwKCHU6qZii/K/2L5XRRKxYUgmmVg==",
       "dependencies": {
         "@matrixai/async-init": "^1.10.0",
         "@matrixai/contexts": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@matrixai/mdns": "^1.2.6",
     "@matrixai/quic": "^1.3.1",
     "@matrixai/resources": "^1.1.5",
-    "@matrixai/rpc": "^0.6.0",
+    "@matrixai/rpc": "^0.6.2",
     "@matrixai/timer": "^1.1.3",
     "@matrixai/workers": "^1.3.7",
     "@matrixai/ws": "^1.1.7",

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -18,6 +18,11 @@ class ErrorClientAuthDenied<T> extends ErrorClient<T> {
   exitCode = sysexits.NOPERM;
 }
 
+class ErrorClientInvalidHeader<T> extends ErrorClient<T> {
+  static description = 'The header message does not match the expected type'
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorClientService<T> extends ErrorClient<T> {}
 
 class ErrorClientServiceRunning<T> extends ErrorClientService<T> {
@@ -45,6 +50,7 @@ export {
   ErrorClientAuthMissing,
   ErrorClientAuthFormat,
   ErrorClientAuthDenied,
+  ErrorClientInvalidHeader,
   ErrorClientService,
   ErrorClientServiceRunning,
   ErrorClientServiceNotRunning,

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -23,6 +23,11 @@ class ErrorClientInvalidHeader<T> extends ErrorClient<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorClientProtocolError<T> extends ErrorClient<T> {
+  static description = 'Data does not match the protocol requirements';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorClientService<T> extends ErrorClient<T> {}
 
 class ErrorClientServiceRunning<T> extends ErrorClientService<T> {
@@ -51,6 +56,7 @@ export {
   ErrorClientAuthFormat,
   ErrorClientAuthDenied,
   ErrorClientInvalidHeader,
+  ErrorClientProtocolError,
   ErrorClientService,
   ErrorClientServiceRunning,
   ErrorClientServiceNotRunning,

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -19,7 +19,7 @@ class ErrorClientAuthDenied<T> extends ErrorClient<T> {
 }
 
 class ErrorClientInvalidHeader<T> extends ErrorClient<T> {
-  static description = 'The header message does not match the expected type'
+  static description = 'The header message does not match the expected type';
   exitCode = sysexits.USAGE;
 }
 

--- a/src/client/handlers/VaultsSecretsCat.ts
+++ b/src/client/handlers/VaultsSecretsCat.ts
@@ -23,7 +23,9 @@ class VaultsSecretsCat extends DuplexHandler<
   ClientRPCResponseResult<ContentOrErrorMessage>
 > {
   public handle = async function* (
-    input: AsyncIterable<ClientRPCRequestParams<SecretIdentifierMessage>>,
+    input: AsyncIterableIterator<
+      ClientRPCRequestParams<SecretIdentifierMessage>
+    >,
   ): AsyncGenerator<ClientRPCResponseResult<ContentOrErrorMessage>> {
     const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;

--- a/src/client/handlers/VaultsSecretsEnv.ts
+++ b/src/client/handlers/VaultsSecretsEnv.ts
@@ -10,7 +10,7 @@ import { DuplexHandler } from '@matrixai/rpc';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
 
-class VaultsSecretsList extends DuplexHandler<
+class VaultsSecretsEnv extends DuplexHandler<
   {
     db: DB;
     vaultManager: VaultManager;
@@ -86,4 +86,4 @@ class VaultsSecretsList extends DuplexHandler<
   };
 }
 
-export default VaultsSecretsList;
+export default VaultsSecretsEnv;

--- a/src/client/handlers/VaultsSecretsMkdir.ts
+++ b/src/client/handlers/VaultsSecretsMkdir.ts
@@ -21,7 +21,7 @@ class VaultsSecretsMkdir extends DuplexHandler<
   ClientRPCResponseResult<SuccessOrErrorMessage>
 > {
   public handle = async function* (
-    input: AsyncIterable<ClientRPCRequestParams<SecretDirMessage>>,
+    input: AsyncIterableIterator<ClientRPCRequestParams<SecretDirMessage>>,
   ): AsyncGenerator<ClientRPCResponseResult<SuccessOrErrorMessage>> {
     const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;

--- a/src/client/handlers/VaultsSecretsRemove.ts
+++ b/src/client/handlers/VaultsSecretsRemove.ts
@@ -1,103 +1,204 @@
 import type { DB } from '@matrixai/db';
+import { ResourceAcquire, withG } from '@matrixai/resources';
 import type {
   ClientRPCRequestParams,
   ClientRPCResponseResult,
-  SecretIdentifierMessage,
+  SecretsRemoveHeaderMessage,
+  SecretIdentifierMessageTagged,
   SuccessOrErrorMessage,
 } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
 import { DuplexHandler } from '@matrixai/rpc';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
+import * as clientErrors from '../errors';
+import { FileSystemWritable } from '../../vaults/types';
+import * as utils from '../../utils';
 
 class VaultsSecretsRemove extends DuplexHandler<
   {
     db: DB;
     vaultManager: VaultManager;
   },
-  ClientRPCRequestParams<SecretIdentifierMessage>,
+  ClientRPCRequestParams<
+    SecretsRemoveHeaderMessage | SecretIdentifierMessageTagged
+  >,
   ClientRPCResponseResult<SuccessOrErrorMessage>
 > {
   public handle = async function* (
-    input: AsyncIterable<ClientRPCRequestParams<SecretIdentifierMessage>>,
+    input: AsyncIterable<
+      ClientRPCRequestParams<
+        SecretsRemoveHeaderMessage | SecretIdentifierMessageTagged
+      >
+    >,
   ): AsyncGenerator<ClientRPCResponseResult<SuccessOrErrorMessage>> {
     const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;
-    // Create a record of secrets to be removed, grouped by vault names
-    const vaultGroups: Record<string, Array<string>> = {};
-    const secretNames: Array<[string, string]> = [];
-    let metadata: any = undefined;
-    for await (const secretRemoveMessage of input) {
-      if (metadata == null) metadata = secretRemoveMessage.metadata ?? {};
-      secretNames.push([
-        secretRemoveMessage.nameOrId,
-        secretRemoveMessage.secretName,
-      ]);
-    }
-    secretNames.forEach(([vaultName, secretName]) => {
-      if (vaultGroups[vaultName] == null) {
-        vaultGroups[vaultName] = [];
+    const vaultAcquires: Array<ResourceAcquire<FileSystemWritable>> = [];
+    // Extracts the header message from the iterator
+    const headerMessage = await (async () => {
+      let header: SecretsRemoveHeaderMessage | undefined;
+      for await (const value of input) {
+        // TS cannot properly narrow down this type as it is too deeply wrapped.
+        // The as keyword is used to help it with type narrowing.
+        const message = value as
+          | SecretIdentifierMessageTagged
+          | SecretsRemoveHeaderMessage;
+        if (message.type === 'VaultNamesHeaderMesage') header = message;
+        break;
       }
-      vaultGroups[vaultName].push(secretName);
+      // The header message is mandatory
+      if (header == null) throw new clientErrors.ErrorClientInvalidHeader();
+      return header;
+    })();
+    // Create an array of write acquires
+    await db.withTransactionF(async (tran) => {
+      for (const vaultName of headerMessage!.vaultNames) {
+        const vaultIdFromName = await vaultManager.getVaultId(vaultName, tran);
+        const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
+        if (vaultId == null) {
+          throw new vaultsErrors.ErrorVaultsVaultUndefined(
+            `Vault ${vaultName} does not exist`,
+          );
+        }
+        await vaultManager.withVaults([vaultId], async (vault) => {
+          vaultAcquires.push(vault.acquireWrite());
+        });
+      }
     });
-    // Now, all the paths will be removed for a vault within a single commit
-    yield* db.withTransactionG(
-      async function* (tran): AsyncGenerator<SuccessOrErrorMessage> {
-        for (const [vaultName, secretNames] of Object.entries(vaultGroups)) {
-          const vaultIdFromName = await vaultManager.getVaultId(
-            vaultName,
-            tran,
-          );
-          const vaultId =
-            vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
-          if (vaultId == null) {
-            throw new vaultsErrors.ErrorVaultsVaultUndefined();
-          }
-          yield* vaultManager.withVaultsG(
-            [vaultId],
-            async function* (vault): AsyncGenerator<SuccessOrErrorMessage> {
-              yield* vault.writeG(
-                async function* (efs): AsyncGenerator<SuccessOrErrorMessage> {
-                  for (const secretName of secretNames) {
-                    try {
-                      const stat = await efs.stat(secretName);
-                      if (stat.isDirectory()) {
-                        await efs.rmdir(secretName, {
-                          recursive: metadata?.options?.recursive,
-                        });
-                      } else {
-                        await efs.unlink(secretName);
-                      }
-                      yield {
-                        type: 'success',
-                        success: true,
-                      };
-                    } catch (e) {
-                      if (
-                        e.code === 'ENOENT' ||
-                        e.code === 'ENOTEMPTY' ||
-                        e.code === 'EINVAL'
-                      ) {
-                        // INVAL can be triggered if removing the root of the
-                        // vault is attempted.
-                        yield {
-                          type: 'error',
-                          code: e.code,
-                          reason: secretName,
-                        };
-                      } else {
-                        throw e;
-                      }
-                    }
-                  }
-                },
+    // Acquire all locks in parallel and perform all operations at once
+    yield* withG(
+      vaultAcquires,
+      async function* (efses): AsyncGenerator<SuccessOrErrorMessage> {
+        // Creating the vault name to efs map for easy access
+        const vaultMap = new Map<string, FileSystemWritable>();
+        for (let i = 0; i < efses.length; i++) {
+          vaultMap.set(headerMessage!.vaultNames[i], efses[i]);
+        }
+        for await (const value of input) {
+          // TS cannot properly narrow down this type as it is too deeply wrapped.
+          // The as keyword is used to help it with type narrowing.
+          const message = value as
+            | SecretIdentifierMessageTagged
+            | SecretsRemoveHeaderMessage;
+          // Ignoring any header messages
+          if (message.type === 'SecretIdentifierMessage') {
+            const efs = vaultMap.get(message.nameOrId);
+            if (efs == null) {
+              throw new vaultsErrors.ErrorVaultsVaultUndefined(
+                `Vault ${message.nameOrId} was not present in the header message`,
               );
-            },
-            tran,
-          );
+            }
+            try {
+              const stat = await efs.stat(message.secretName);
+              if (stat.isDirectory()) {
+                await efs.rmdir(message.secretName, {
+                  recursive: headerMessage.recursive,
+                });
+              } else {
+                await efs.unlink(message.secretName);
+              }
+              yield {
+                type: 'success',
+                success: true,
+              };
+            } catch (e) {
+              if (
+                e.code === 'ENOENT' ||
+                e.code === 'ENOTEMPTY' ||
+                e.code === 'EINVAL'
+              ) {
+                // INVAL can be triggered if removing the root of the
+                // vault is attempted.
+                yield {
+                  type: 'error',
+                  code: e.code,
+                  reason: message.secretName,
+                };
+              } else {
+                throw e;
+              }
+            }
+          }
         }
       },
     );
+
+    // Create a record of secrets to be removed, grouped by vault names
+    // const vaultGroups: Record<string, Array<string>> = {};
+    // const secretNames: Array<[string, string]> = [];
+    // let metadata: any = undefined;
+    // for await (const secretRemoveMessage of input) {
+    //   if (metadata == null) metadata = secretRemoveMessage.metadata ?? {};
+    //   secretNames.push([
+    //     secretRemoveMessage.nameOrId,
+    //     secretRemoveMessage.secretName,
+    //   ]);
+    // }
+    // secretNames.forEach(([vaultName, secretName]) => {
+    //   if (vaultGroups[vaultName] == null) {
+    //     vaultGroups[vaultName] = [];
+    //   }
+    //   vaultGroups[vaultName].push(secretName);
+    // });
+    // Now, all the paths will be removed for a vault within a single commit
+    // yield* db.withTransactionG(
+    //   async function* (tran): AsyncGenerator<SuccessOrErrorMessage> {
+    //     for (const [vaultName, secretNames] of Object.entries(vaultGroups)) {
+    //       const vaultIdFromName = await vaultManager.getVaultId(
+    //         vaultName,
+    //         tran,
+    //       );
+    //       const vaultId =
+    //         vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
+    //       if (vaultId == null) {
+    //         throw new vaultsErrors.ErrorVaultsVaultUndefined();
+    //       }
+    //       yield* vaultManager.withVaultsG(
+    //         [vaultId],
+    //         async function* (vault): AsyncGenerator<SuccessOrErrorMessage> {
+    //           yield* vault.writeG(
+    //             async function* (efs): AsyncGenerator<SuccessOrErrorMessage> {
+    //               for (const secretName of secretNames) {
+    //                 try {
+    //                   const stat = await efs.stat(secretName);
+    //                   if (stat.isDirectory()) {
+    //                     await efs.rmdir(secretName, {
+    //                       recursive: metadata?.options?.recursive,
+    //                     });
+    //                   } else {
+    //                     await efs.unlink(secretName);
+    //                   }
+    //                   yield {
+    //                     type: 'success',
+    //                     success: true,
+    //                   };
+    //                 } catch (e) {
+    //                   if (
+    //                     e.code === 'ENOENT' ||
+    //                     e.code === 'ENOTEMPTY' ||
+    //                     e.code === 'EINVAL'
+    //                   ) {
+    //                     // INVAL can be triggered if removing the root of the
+    //                     // vault is attempted.
+    //                     yield {
+    //                       type: 'error',
+    //                       code: e.code,
+    //                       reason: secretName,
+    //                     };
+    //                   } else {
+    //                     throw e;
+    //                   }
+    //                 }
+    //               }
+    //             },
+    //           );
+    //         },
+    //         tran,
+    //       );
+    //     }
+    //   },
+    // );
   };
 }
 

--- a/src/client/handlers/VaultsSecretsRemove.ts
+++ b/src/client/handlers/VaultsSecretsRemove.ts
@@ -35,11 +35,13 @@ class VaultsSecretsRemove extends DuplexHandler<
     const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;
     // Extract the header message from the iterator
+    const headerMessagePair = await input.next();
     const headerMessage:
       | SecretsRemoveHeaderMessage
-      | SecretIdentifierMessageTagged = (await input.next()).value;
+      | SecretIdentifierMessageTagged = headerMessagePair.value;
+    // Testing if the header is of the expected format
     if (
-      headerMessage == null ||
+      headerMessagePair.done ||
       headerMessage.type !== 'VaultNamesHeaderMessage'
     ) {
       throw new clientErrors.ErrorClientInvalidHeader();
@@ -72,10 +74,12 @@ class VaultsSecretsRemove extends DuplexHandler<
         for (let i = 0; i < efses.length; i++) {
           vaultMap.set(headerMessage!.vaultNames[i], efses[i]);
         }
+        let loopRan = false;
         for await (const message of input) {
-          // Ignoring any header messages
+          loopRan = true;
+          // Header messages should not be seen anymore
           if (message.type === 'VaultNamesHeaderMessage') {
-            throw new clientErrors.ErrorClientInvalidHeader(
+            throw new clientErrors.ErrorClientProtocolError(
               'The header message cannot be sent multiple times',
             );
           }
@@ -115,6 +119,12 @@ class VaultsSecretsRemove extends DuplexHandler<
               throw e;
             }
           }
+        }
+        // Content messages must follow header messages
+        if (!loopRan) {
+          throw new clientErrors.ErrorClientProtocolError(
+            'No content messages followed header message',
+          );
         }
       },
     );

--- a/src/client/handlers/VaultsSecretsRemove.ts
+++ b/src/client/handlers/VaultsSecretsRemove.ts
@@ -1,5 +1,5 @@
 import type { DB } from '@matrixai/db';
-import { ResourceAcquire, withG } from '@matrixai/resources';
+import type { ResourceAcquire } from '@matrixai/resources';
 import type {
   ClientRPCRequestParams,
   ClientRPCResponseResult,
@@ -8,12 +8,12 @@ import type {
   SuccessOrErrorMessage,
 } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
+import type { FileSystemWritable } from '../../vaults/types';
+import { withG } from '@matrixai/resources';
 import { DuplexHandler } from '@matrixai/rpc';
 import * as vaultsUtils from '../../vaults/utils';
 import * as vaultsErrors from '../../vaults/errors';
 import * as clientErrors from '../errors';
-import { FileSystemWritable } from '../../vaults/types';
-import * as utils from '../../utils';
 
 class VaultsSecretsRemove extends DuplexHandler<
   {
@@ -37,23 +37,16 @@ class VaultsSecretsRemove extends DuplexHandler<
     const vaultAcquires: Array<ResourceAcquire<FileSystemWritable>> = [];
     // Extracts the header message from the iterator
     const headerMessage = await (async () => {
-      let header: SecretsRemoveHeaderMessage | undefined;
-      for await (const value of input) {
-        // TS cannot properly narrow down this type as it is too deeply wrapped.
-        // The as keyword is used to help it with type narrowing.
-        const message = value as
-          | SecretIdentifierMessageTagged
-          | SecretsRemoveHeaderMessage;
-        if (message.type === 'VaultNamesHeaderMesage') header = message;
-        break;
+      const iterator = input[Symbol.asyncIterator]();
+      const header = (await iterator.next()).value;
+      if (header.type === 'VaultNamesHeaderMessage') {
+        if (header == null) throw new clientErrors.ErrorClientInvalidHeader();
+        return header;
       }
-      // The header message is mandatory
-      if (header == null) throw new clientErrors.ErrorClientInvalidHeader();
-      return header;
     })();
     // Create an array of write acquires
     await db.withTransactionF(async (tran) => {
-      for (const vaultName of headerMessage!.vaultNames) {
+      for (const vaultName of headerMessage.vaultNames) {
         const vaultIdFromName = await vaultManager.getVaultId(vaultName, tran);
         const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
         if (vaultId == null) {
@@ -61,9 +54,11 @@ class VaultsSecretsRemove extends DuplexHandler<
             `Vault ${vaultName} does not exist`,
           );
         }
-        await vaultManager.withVaults([vaultId], async (vault) => {
-          vaultAcquires.push(vault.acquireWrite());
-        });
+        const acquire = await vaultManager.withVaults(
+          [vaultId],
+          async (vault) => vault.acquireWrite(),
+        );
+        vaultAcquires.push(acquire);
       }
     });
     // Acquire all locks in parallel and perform all operations at once
@@ -75,130 +70,48 @@ class VaultsSecretsRemove extends DuplexHandler<
         for (let i = 0; i < efses.length; i++) {
           vaultMap.set(headerMessage!.vaultNames[i], efses[i]);
         }
-        for await (const value of input) {
-          // TS cannot properly narrow down this type as it is too deeply wrapped.
-          // The as keyword is used to help it with type narrowing.
-          const message = value as
-            | SecretIdentifierMessageTagged
-            | SecretsRemoveHeaderMessage;
+        for await (const message of input) {
           // Ignoring any header messages
-          if (message.type === 'SecretIdentifierMessage') {
-            const efs = vaultMap.get(message.nameOrId);
-            if (efs == null) {
-              throw new vaultsErrors.ErrorVaultsVaultUndefined(
-                `Vault ${message.nameOrId} was not present in the header message`,
-              );
+          if (message.type !== 'SecretIdentifierMessage') continue;
+          const efs = vaultMap.get(message.nameOrId);
+          if (efs == null) {
+            throw new vaultsErrors.ErrorVaultsVaultUndefined(
+              `Vault ${message.nameOrId} was not present in the header message`,
+            );
+          }
+          try {
+            const stat = await efs.stat(message.secretName);
+            if (stat.isDirectory()) {
+              await efs.rmdir(message.secretName, {
+                recursive: headerMessage.recursive,
+              });
+            } else {
+              await efs.unlink(message.secretName);
             }
-            try {
-              const stat = await efs.stat(message.secretName);
-              if (stat.isDirectory()) {
-                await efs.rmdir(message.secretName, {
-                  recursive: headerMessage.recursive,
-                });
-              } else {
-                await efs.unlink(message.secretName);
-              }
+            yield {
+              type: 'success',
+              success: true,
+            };
+          } catch (e) {
+            if (
+              e.code === 'ENOENT' ||
+              e.code === 'ENOTEMPTY' ||
+              e.code === 'EINVAL'
+            ) {
+              // INVAL can be triggered if removing the root of the
+              // vault is attempted.
               yield {
-                type: 'success',
-                success: true,
+                type: 'error',
+                code: e.code,
+                reason: message.secretName,
               };
-            } catch (e) {
-              if (
-                e.code === 'ENOENT' ||
-                e.code === 'ENOTEMPTY' ||
-                e.code === 'EINVAL'
-              ) {
-                // INVAL can be triggered if removing the root of the
-                // vault is attempted.
-                yield {
-                  type: 'error',
-                  code: e.code,
-                  reason: message.secretName,
-                };
-              } else {
-                throw e;
-              }
+            } else {
+              throw e;
             }
           }
         }
       },
     );
-
-    // Create a record of secrets to be removed, grouped by vault names
-    // const vaultGroups: Record<string, Array<string>> = {};
-    // const secretNames: Array<[string, string]> = [];
-    // let metadata: any = undefined;
-    // for await (const secretRemoveMessage of input) {
-    //   if (metadata == null) metadata = secretRemoveMessage.metadata ?? {};
-    //   secretNames.push([
-    //     secretRemoveMessage.nameOrId,
-    //     secretRemoveMessage.secretName,
-    //   ]);
-    // }
-    // secretNames.forEach(([vaultName, secretName]) => {
-    //   if (vaultGroups[vaultName] == null) {
-    //     vaultGroups[vaultName] = [];
-    //   }
-    //   vaultGroups[vaultName].push(secretName);
-    // });
-    // Now, all the paths will be removed for a vault within a single commit
-    // yield* db.withTransactionG(
-    //   async function* (tran): AsyncGenerator<SuccessOrErrorMessage> {
-    //     for (const [vaultName, secretNames] of Object.entries(vaultGroups)) {
-    //       const vaultIdFromName = await vaultManager.getVaultId(
-    //         vaultName,
-    //         tran,
-    //       );
-    //       const vaultId =
-    //         vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
-    //       if (vaultId == null) {
-    //         throw new vaultsErrors.ErrorVaultsVaultUndefined();
-    //       }
-    //       yield* vaultManager.withVaultsG(
-    //         [vaultId],
-    //         async function* (vault): AsyncGenerator<SuccessOrErrorMessage> {
-    //           yield* vault.writeG(
-    //             async function* (efs): AsyncGenerator<SuccessOrErrorMessage> {
-    //               for (const secretName of secretNames) {
-    //                 try {
-    //                   const stat = await efs.stat(secretName);
-    //                   if (stat.isDirectory()) {
-    //                     await efs.rmdir(secretName, {
-    //                       recursive: metadata?.options?.recursive,
-    //                     });
-    //                   } else {
-    //                     await efs.unlink(secretName);
-    //                   }
-    //                   yield {
-    //                     type: 'success',
-    //                     success: true,
-    //                   };
-    //                 } catch (e) {
-    //                   if (
-    //                     e.code === 'ENOENT' ||
-    //                     e.code === 'ENOTEMPTY' ||
-    //                     e.code === 'EINVAL'
-    //                   ) {
-    //                     // INVAL can be triggered if removing the root of the
-    //                     // vault is attempted.
-    //                     yield {
-    //                       type: 'error',
-    //                       code: e.code,
-    //                       reason: secretName,
-    //                     };
-    //                   } else {
-    //                     throw e;
-    //                   }
-    //                 }
-    //               }
-    //             },
-    //           );
-    //         },
-    //         tran,
-    //       );
-    //     }
-    //   },
-    // );
   };
 }
 

--- a/src/client/handlers/VaultsSecretsRemove.ts
+++ b/src/client/handlers/VaultsSecretsRemove.ts
@@ -26,7 +26,7 @@ class VaultsSecretsRemove extends DuplexHandler<
   ClientRPCResponseResult<SuccessOrErrorMessage>
 > {
   public handle = async function* (
-    input: AsyncIterable<
+    input: AsyncIterableIterator<
       ClientRPCRequestParams<
         SecretsRemoveHeaderMessage | SecretIdentifierMessageTagged
       >
@@ -34,18 +34,19 @@ class VaultsSecretsRemove extends DuplexHandler<
   ): AsyncGenerator<ClientRPCResponseResult<SuccessOrErrorMessage>> {
     const { db, vaultManager }: { db: DB; vaultManager: VaultManager } =
       this.container;
-    const vaultAcquires: Array<ResourceAcquire<FileSystemWritable>> = [];
-    // Extracts the header message from the iterator
-    const headerMessage = await (async () => {
-      const iterator = input[Symbol.asyncIterator]();
-      const header = (await iterator.next()).value;
-      if (header.type === 'VaultNamesHeaderMessage') {
-        if (header == null) throw new clientErrors.ErrorClientInvalidHeader();
-        return header;
-      }
-    })();
+    // Extract the header message from the iterator
+    const headerMessage:
+      | SecretsRemoveHeaderMessage
+      | SecretIdentifierMessageTagged = (await input.next()).value;
+    if (
+      headerMessage == null ||
+      headerMessage.type !== 'VaultNamesHeaderMessage'
+    ) {
+      throw new clientErrors.ErrorClientInvalidHeader();
+    }
     // Create an array of write acquires
-    await db.withTransactionF(async (tran) => {
+    const vaultAcquires = await db.withTransactionF(async (tran) => {
+      const vaultAcquires: Array<ResourceAcquire<FileSystemWritable>> = [];
       for (const vaultName of headerMessage.vaultNames) {
         const vaultIdFromName = await vaultManager.getVaultId(vaultName, tran);
         const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(vaultName);
@@ -60,6 +61,7 @@ class VaultsSecretsRemove extends DuplexHandler<
         );
         vaultAcquires.push(acquire);
       }
+      return vaultAcquires;
     });
     // Acquire all locks in parallel and perform all operations at once
     yield* withG(
@@ -72,7 +74,11 @@ class VaultsSecretsRemove extends DuplexHandler<
         }
         for await (const message of input) {
           // Ignoring any header messages
-          if (message.type !== 'SecretIdentifierMessage') continue;
+          if (message.type === 'VaultNamesHeaderMessage') {
+            throw new clientErrors.ErrorClientInvalidHeader(
+              'The header message cannot be sent multiple times',
+            );
+          }
           const efs = vaultMap.get(message.nameOrId);
           if (efs == null) {
             throw new vaultsErrors.ErrorVaultsVaultUndefined(
@@ -98,7 +104,7 @@ class VaultsSecretsRemove extends DuplexHandler<
               e.code === 'ENOTEMPTY' ||
               e.code === 'EINVAL'
             ) {
-              // INVAL can be triggered if removing the root of the
+              // EINVAL can be triggered if removing the root of the
               // vault is attempted.
               yield {
                 type: 'error',

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,8 +1,7 @@
 import type {
   ClientManifest,
   JSONObject,
-  JSONRPCResponseMetadata,
-  // JSONRPCResponseResult,
+  JSONRPCResponseResult,
   RPCClient,
 } from '@matrixai/rpc';
 import type {
@@ -25,16 +24,6 @@ import type {
   NodeContactAddressData,
 } from '../nodes/types';
 import type { AuditEventsGetTypeOverride } from './callers/auditEventsGet';
-
-// TEMP: For testing and debugging. This will go into js-rpc or something.
-type JSONRPCResponseResult<
-  T extends JSONObject = JSONObject,
-  M extends JSONObject = JSONObject,
-> = T & {
-  metadata?: JSONRPCResponseMetadata &
-    M &
-    (T extends { metadata: infer U } ? U : JSONObject);
-};
 
 type ClientRPCRequestParams<T extends JSONObject = JSONObject> =
   JSONRPCResponseResult<

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,7 +1,8 @@
 import type {
   ClientManifest,
   JSONObject,
-  JSONRPCResponseResult,
+  JSONRPCResponseMetadata,
+  // JSONRPCResponseResult,
   RPCClient,
 } from '@matrixai/rpc';
 import type {
@@ -24,6 +25,16 @@ import type {
   NodeContactAddressData,
 } from '../nodes/types';
 import type { AuditEventsGetTypeOverride } from './callers/auditEventsGet';
+
+// TEMP: For testing and debugging. This will go into js-rpc or something.
+type JSONRPCResponseResult<
+  T extends JSONObject = JSONObject,
+  M extends JSONObject = JSONObject,
+> = T & {
+  metadata?: JSONRPCResponseMetadata &
+    M &
+    (T extends { metadata: infer U } ? U : JSONObject);
+};
 
 type ClientRPCRequestParams<T extends JSONObject = JSONObject> =
   JSONRPCResponseResult<
@@ -362,14 +373,14 @@ type SecretStatMessage = {
 
 type SecretIdentifierMessageTagged = SecretIdentifierMessage & {
   type: 'SecretIdentifierMessage';
-}
+};
 
-type VaultNamesHeaderMesage = {
-  type: 'VaultNamesHeaderMesage';
+type VaultNamesHeaderMessage = {
+  type: 'VaultNamesHeaderMessage';
   vaultNames: Array<string>;
 };
 
-type SecretsRemoveHeaderMessage = VaultNamesHeaderMesage & {
+type SecretsRemoveHeaderMessage = VaultNamesHeaderMessage & {
   recursive?: boolean;
 };
 
@@ -449,7 +460,7 @@ export type {
   SecretFilesMessage,
   SecretStatMessage,
   SecretIdentifierMessageTagged,
-  VaultNamesHeaderMesage,
+  VaultNamesHeaderMessage,
   SecretsRemoveHeaderMessage,
   SignatureMessage,
   OverrideRPClientType,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -360,6 +360,19 @@ type SecretStatMessage = {
   };
 };
 
+type SecretIdentifierMessageTagged = SecretIdentifierMessage & {
+  type: 'SecretIdentifierMessage';
+}
+
+type VaultNamesHeaderMesage = {
+  type: 'VaultNamesHeaderMesage';
+  vaultNames: Array<string>;
+};
+
+type SecretsRemoveHeaderMessage = VaultNamesHeaderMesage & {
+  recursive?: boolean;
+};
+
 // Type casting for tricky handlers
 
 type OverrideRPClientType<T extends RPCClient<ClientManifest>> = Omit<
@@ -435,6 +448,9 @@ export type {
   SecretRenameMessage,
   SecretFilesMessage,
   SecretStatMessage,
+  SecretIdentifierMessageTagged,
+  VaultNamesHeaderMesage,
+  SecretsRemoveHeaderMessage,
   SignatureMessage,
   OverrideRPClientType,
   AuditMetricGetTypeOverride,

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -218,7 +218,9 @@ async function listObjects({
         }
         return;
       default:
-        utils.never('Invalid type');
+        utils.never(
+          `type must be one of "commit", "tree", "blob", or "tag", got "${type}"`,
+        );
     }
   }
 

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -218,7 +218,7 @@ async function listObjects({
         }
         return;
       default:
-        utils.never();
+        utils.never('Invalid type');
     }
   }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -48,7 +48,7 @@ function getDefaultNodePath(): string | undefined {
   return p;
 }
 
-function never(message?: string): never {
+function never(message: string): never {
   throw new utilsErrors.ErrorUtilsUndefinedBehaviour(message);
 }
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -8,6 +8,8 @@ interface Vault {
   writeG: VaultInternal['writeG'];
   readF: VaultInternal['readF'];
   readG: VaultInternal['readG'];
+  acquireRead: VaultInternal['acquireRead'];
+  acquireWrite: VaultInternal['acquireWrite'];
   log: VaultInternal['log'];
   version: VaultInternal['version'];
 }

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -596,9 +596,6 @@ class VaultInternal {
               await this.createCommit();
             } catch (e_) {
               e = e_;
-            }
-            // This would happen if an error was caught inside the catch block
-            if (e != null) {
               // Error implies dirty state
               await this.cleanWorkingDirectory();
             }

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -1,6 +1,8 @@
 import type { ReadCommitResult } from 'isomorphic-git';
 import type { EncryptedFS } from 'encryptedfs';
 import type { DB, DBTransaction, LevelPath } from '@matrixai/db';
+import type { RPCClient } from '@matrixai/rpc';
+import type { ResourceAcquire, ResourceRelease } from '@matrixai/resources';
 import type {
   CommitId,
   CommitLog,
@@ -15,7 +17,6 @@ import type {
 import type KeyRing from '../keys/KeyRing';
 import type { NodeId, NodeIdEncoded } from '../ids/types';
 import type NodeManager from '../nodes/NodeManager';
-import type { RPCClient } from '@matrixai/rpc';
 import type agentClientManifest from '../nodes/agent/callers';
 import type { POJO } from '../types';
 import path from 'path';
@@ -534,6 +535,86 @@ class VaultInternal {
       await tran.put([...vaultMetadataDbPath, VaultInternal.dirtyKey], false);
       return result;
     });
+  }
+
+  /**
+   * Acquire a read-only lock on this vault
+   */
+  @ready(new vaultsErrors.ErrorVaultNotRunning())
+  public acquireRead(): ResourceAcquire<FileSystemReadable> {
+    return async () => {
+      const acquire = this.lock.read();
+      const [release] = await acquire();
+      return [
+        async (e?: Error) => {
+          await release(e);
+        },
+        this.efsVault,
+      ];
+    };
+  }
+
+  /**
+   * Acquire a read-write lock on this vault
+   */
+  @ready(new vaultsErrors.ErrorVaultNotRunning())
+  public acquireWrite(
+    tran?: DBTransaction,
+  ): ResourceAcquire<FileSystemWritable> {
+    return async () => {
+      let releaseTran: ResourceRelease | undefined = undefined;
+      const acquire = this.lock.write();
+      const [release] = await acquire([tran]);
+      if (tran == null) {
+        const acquireTran = this.db.transaction();
+        [releaseTran, tran] = await acquireTran();
+      }
+      // The returned transaction can be undefined, too. We won't handle those
+      // cases.
+      if (tran == null) utils.never();
+      await tran.lock(
+        [...this.vaultMetadataDbPath, VaultInternal.dirtyKey].join(''),
+      );
+      if (
+        (await tran.get([
+          ...this.vaultMetadataDbPath,
+          VaultInternal.remoteKey,
+        ])) != null
+      ) {
+        // Mirrored vaults are immutable
+        throw new vaultsErrors.ErrorVaultRemoteDefined();
+      }
+      await tran.put(
+        [...this.vaultMetadataDbPath, VaultInternal.dirtyKey],
+        true,
+      );
+      return [
+        async (e?: Error) => {
+          if (e != null) {
+            try {
+              // After doing mutation we need to commit the new history
+              await this.createCommit();
+            } catch (e_) {
+              e = e_;
+            }
+            // This would happen if an error was caught inside the catch block
+            if (e != null) {
+              // Error implies dirty state
+              await this.cleanWorkingDirectory();
+            }
+          }
+          // For some reason, the transaction type doesn't properly waterfall
+          // down to here.
+          await tran!.put(
+            [...this.vaultMetadataDbPath, VaultInternal.dirtyKey],
+            false,
+          );
+          if (releaseTran != null) await releaseTran(e);
+          await release(e);
+        },
+        this.efsVault,
+      ];
+    };
   }
 
   /**

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -571,7 +571,7 @@ class VaultInternal {
       }
       // The returned transaction can be undefined, too. We won't handle those
       // cases.
-      if (tran == null) utils.never();
+      if (tran == null) utils.never('Acquired transactions cannot be null');
       await tran.lock(
         [...this.vaultMetadataDbPath, VaultInternal.dirtyKey].join(''),
       );

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -564,7 +564,7 @@ class VaultInternal {
     return async () => {
       let releaseTran: ResourceRelease | undefined = undefined;
       const acquire = this.lock.write();
-      const [release] = await acquire([tran]);
+      const [release] = await acquire();
       if (tran == null) {
         const acquireTran = this.db.transaction();
         [releaseTran, tran] = await acquireTran();
@@ -590,7 +590,7 @@ class VaultInternal {
       );
       return [
         async (e?: Error) => {
-          if (e != null) {
+          if (e == null) {
             try {
               // After doing mutation we need to commit the new history
               await this.createCommit();

--- a/tests/audit/utils.test.ts
+++ b/tests/audit/utils.test.ts
@@ -47,6 +47,7 @@ describe('Audit Utils', () => {
       ['f'],
       ['f'],
     ];
+    // @ts-ignore: treating TopicSubPath as string for testing
     const filtered = auditUtils.filterSubPaths(data).map((v) => v.join('.'));
     expect(filtered).toHaveLength(3);
     expect(filtered).toInclude('a.b');

--- a/tests/client/handlers/nodes.test.ts
+++ b/tests/client/handlers/nodes.test.ts
@@ -825,7 +825,6 @@ describe('nodesGetAll', () => {
       manifest: {
         nodesGetAll: new NodesGetAll({
           nodeGraph,
-          keyRing,
         }),
       },
       host: localhost,

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -3,13 +3,8 @@ import type { FileSystem } from '@/types';
 import type { VaultId } from '@/ids';
 import type NodeManager from '@/nodes/NodeManager';
 import type {
-    ClientRPCRequestParams,
-  ContentSuccessMessage,
-  ErrorMessage,
   LogEntryMessage,
   SecretContentMessage,
-  SecretIdentifierMessage,
-  SecretsRemoveHeaderMessage,
   VaultListMessage,
   VaultPermissionMessage,
 } from '@/client/types';
@@ -76,6 +71,7 @@ import * as nodesUtils from '@/nodes/utils';
 import * as vaultsUtils from '@/vaults/utils';
 import * as vaultsErrors from '@/vaults/errors';
 import * as networkUtils from '@/network/utils';
+import * as utils from '@/utils';
 import * as testsUtils from '../../utils';
 
 describe('vaultsClone', () => {
@@ -1486,11 +1482,9 @@ describe('vaultsSecretsMkdir', () => {
     await writer.close();
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'error'.
-      const error = data as ErrorMessage;
-      expect(error.code).toEqual('ENOENT');
-      expect(error.reason).toEqual(dirPath);
+      if (data.type !== 'error') utils.never();
+      expect(data.code).toEqual('ENOENT');
+      expect(data.reason).toEqual(dirPath);
     }
     await vaultManager.withVaults([vaultId], async (vault) => {
       await vault.readF(async (efs) => {
@@ -1556,11 +1550,8 @@ describe('vaultsSecretsMkdir', () => {
     // Check if the operation concluded as expected
     for await (const data of response.readable) {
       if (data.type === 'error') {
-        // TS cannot properly evaluate a type as nested as this, so we use the
-        // as keyword to help it. Inside this block, the type of data is 'error'.
-        const error = data as ErrorMessage;
-        expect(error.code).toEqual('ENOENT');
-        expect(error.reason).toEqual(dirPath3);
+        expect(data.code).toEqual('ENOENT');
+        expect(data.reason).toEqual(dirPath3);
       }
     }
     await vaultManager.withVaults(
@@ -1594,11 +1585,9 @@ describe('vaultsSecretsMkdir', () => {
     // Check if the operation concluded as expected
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'error'.
-      const error = data as ErrorMessage;
-      expect(error.code).toEqual('EEXIST');
-      expect(error.reason).toEqual(dirPath);
+      if (data.type !== 'error') utils.never();
+      expect(data.code).toEqual('EEXIST');
+      expect(data.reason).toEqual(dirPath);
     }
     await vaultManager.withVaults([vaultId], async (vault) => {
       await vault.readF(async (efs) => {
@@ -1739,10 +1728,8 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'success'.
-      const message = data as ContentSuccessMessage;
-      expect(message.secretContent).toEqual(secretContent);
+      if (data.type !== 'success') utils.never();
+      expect(data.secretContent).toEqual(secretContent);
     }
   });
   test('fails to read invalid secret', async () => {
@@ -1760,11 +1747,9 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'success'.
-      const error = data as ErrorMessage;
-      expect(error.code).toEqual('ENOENT');
-      expect(error.reason).toEqual(secretName);
+      if (data.type !== 'error') utils.never();
+      expect(data.code).toEqual('ENOENT');
+      expect(data.reason).toEqual(secretName);
     }
   });
   test('fails to read a directory', async () => {
@@ -1788,11 +1773,9 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'success'.
-      const error = data as ErrorMessage;
-      expect(error.code).toEqual('EISDIR');
-      expect(error.reason).toEqual(secretName);
+      if (data.type !== 'error') utils.never();
+      expect(data.code).toEqual('EISDIR');
+      expect(data.reason).toEqual(secretName);
     }
   });
   test('reads multiple secrets in order', async () => {
@@ -1820,10 +1803,8 @@ describe('vaultsSecretsCat', () => {
     let totalContent = '';
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'success'.
-      const message = data as ContentSuccessMessage;
-      totalContent += message.secretContent;
+      if (data.type !== 'success') utils.never();
+      totalContent += data.secretContent;
     }
     expect(totalContent).toEqual(`${secretContent1}${secretContent2}`);
   });
@@ -1864,10 +1845,8 @@ describe('vaultsSecretsCat', () => {
     let totalContent = '';
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'success'.
-      const message = data as ContentSuccessMessage;
-      totalContent += message.secretContent;
+      if (data.type !== 'success') utils.never();
+      totalContent += data.secretContent;
     }
     expect(totalContent).toEqual(
       `${secretContent1}${secretContent2}${secretContent3}`,
@@ -1913,16 +1892,10 @@ describe('vaultsSecretsCat', () => {
     let totalContent = '';
     for await (const data of response.readable) {
       if (data.type === 'success') {
-        // TS cannot properly evaluate a type as nested as this, so we use the
-        // as keyword to help it. Inside this block, the type of data is 'success'.
-        const message = data as ContentSuccessMessage;
-        totalContent += message.secretContent;
+        totalContent += data.secretContent;
       } else {
-        // TS cannot properly evaluate a type as nested as this, so we use the
-        // as keyword to help it. Inside this block, the type of data is 'success'.
-        const error = data as ErrorMessage;
-        expect(error.code).toEqual('ENOENT');
-        expect(error.reason).toEqual(invalidName);
+        expect(data.code).toEqual('ENOENT');
+        expect(data.reason).toEqual(invalidName);
       }
     }
     expect(totalContent).toEqual(
@@ -2374,11 +2347,9 @@ describe('vaultsSecretsRemove', () => {
     // Write paths
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    let variable: ClientRPCRequestParams<SecretsRemoveHeaderMessage | SecretIdentifierMessage> = {type: 'VaultNamesHeaderMesage', vaultNames: ['invalid']};
-    console.log(variable);
     // Header message
     await writer.write({
-      type: 'VaultNamesHeaderMesage',
+      type: 'VaultNamesHeaderMessage',
       vaultNames: ['invalid'],
     });
     // Content messages
@@ -2410,17 +2381,27 @@ describe('vaultsSecretsRemove', () => {
     // Delete secrets
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: '/' });
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: '/',
+    });
     await writer.close();
+    let loopRun = false;
     for await (const data of response.readable) {
+      loopRun = true;
       expect(data.type).toStrictEqual('error');
-      // TS cannot properly evaluate a type as nested as this, so we use the
-      // as keyword to help it. Inside this block, the type of data is 'error'.
-      const error = data as ErrorMessage;
-      // The error code should be an invalid operation
-      expect(error.code).toStrictEqual('EINVAL');
+      if (data.type !== 'error') utils.never();
+      expect(data.code).toStrictEqual('EINVAL');
     }
     // Check
+    expect(loopRun).toBeTruthy();
     await vaultManager.withVaults([vaultId], async (vault) => {
       await vault.readF(async (efs) => {
         expect(await efs.exists(secretName)).toBeTruthy();
@@ -2442,12 +2423,29 @@ describe('vaultsSecretsRemove', () => {
     // Delete secrets
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName1 });
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName2 });
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName1,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName2,
+    });
     await writer.close();
+    let loopRun = false;
     for await (const data of response.readable) {
+      loopRun = true;
       expect(data.type).toStrictEqual('success');
     }
+    expect(loopRun).toBeTruthy();
     // Check each secret was deleted
     await vaultManager.withVaults([vaultId], async (vault) => {
       await vault.readF(async (efs) => {
@@ -2472,18 +2470,33 @@ describe('vaultsSecretsRemove', () => {
     // Delete secrets
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName1 });
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: invalidName });
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName2 });
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName1,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: invalidName,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName2,
+    });
     await writer.close();
     let errorCount = 0;
     for await (const data of response.readable) {
       if (data.type === 'error') {
-        // TS cannot properly evaluate a type as nested as this, so we use the
-        // as keyword to help it. Inside this block, the type of data is 'error'.
-        const error = data as ErrorMessage;
         // No other file name should raise this error
-        expect(error.reason).toStrictEqual(invalidName);
+        expect(data.reason).toStrictEqual(invalidName);
         errorCount++;
         continue;
       }
@@ -2519,12 +2532,29 @@ describe('vaultsSecretsRemove', () => {
     // Delete secret
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName1 });
-    await writer.write({ nameOrId: vaultIdEncoded, secretName: secretName2 });
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName1,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded,
+      secretName: secretName2,
+    });
     await writer.close();
+    let loopRun = false;
     for await (const data of response.readable) {
+      loopRun = true;
       expect(data.type).toStrictEqual('success');
     }
+    expect(loopRun).toBeTruthy();
     // Ensure single log message for deleting the secrets
     await vaultManager.withVaults([vaultId], async (vault) => {
       expect((await vault.log()).length).toEqual(logLength + 1);
@@ -2555,14 +2585,35 @@ describe('vaultsSecretsRemove', () => {
     // Delete secret
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded1, secretName: secretName1 });
-    await writer.write({ nameOrId: vaultIdEncoded2, secretName: secretName2 });
-    await writer.write({ nameOrId: vaultIdEncoded1, secretName: secretName3 });
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded1, vaultIdEncoded2],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded1,
+      secretName: secretName1,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded2,
+      secretName: secretName2,
+    });
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: vaultIdEncoded1,
+      secretName: secretName3,
+    });
     await writer.close();
+    let loopRun = false;
     for await (const data of response.readable) {
+      loopRun = true;
       expect(data.type).toStrictEqual('success');
     }
     // Ensure single log message for deleting the secrets
+    expect(loopRun).toBeTruthy();
     await vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -2595,10 +2646,17 @@ describe('vaultsSecretsRemove', () => {
     // Deleting directory with recursive set should not fail
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
+    // Header message
     await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+      recursive: true,
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
       nameOrId: vaultIdEncoded,
       secretName: dirName,
-      metadata: { options: { recursive: true } },
     });
     await writer.close();
     for await (const data of response.readable) {
@@ -2632,7 +2690,14 @@ describe('vaultsSecretsRemove', () => {
     // Deleting directory with recursive set should not fail
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
+    // Header message
     await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
       nameOrId: vaultIdEncoded,
       secretName: dirName,
     });

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -3,10 +3,13 @@ import type { FileSystem } from '@/types';
 import type { VaultId } from '@/ids';
 import type NodeManager from '@/nodes/NodeManager';
 import type {
+    ClientRPCRequestParams,
   ContentSuccessMessage,
   ErrorMessage,
   LogEntryMessage,
   SecretContentMessage,
+  SecretIdentifierMessage,
+  SecretsRemoveHeaderMessage,
   VaultListMessage,
   VaultPermissionMessage,
 } from '@/client/types';
@@ -2371,7 +2374,19 @@ describe('vaultsSecretsRemove', () => {
     // Write paths
     const response = await rpcClient.methods.vaultsSecretsRemove();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: 'invalid', secretName: 'invalid' });
+    let variable: ClientRPCRequestParams<SecretsRemoveHeaderMessage | SecretIdentifierMessage> = {type: 'VaultNamesHeaderMesage', vaultNames: ['invalid']};
+    console.log(variable);
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMesage',
+      vaultNames: ['invalid'],
+    });
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: 'invalid',
+      secretName: 'invalid',
+    });
     await writer.close();
     // Read response
     const consumeP = async () => {

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -1453,6 +1453,7 @@ describe('vaultsSecretsMkdir', () => {
     const vaultName = 'test-vault';
     const vaultId = await vaultManager.createVault(vaultName);
     const dirPath = 'dir/dir1/dir2';
+    // Attempt to make directories
     const response = await rpcClient.methods.vaultsSecretsMkdir();
     const writer = response.writable.getWriter();
     await writer.write({
@@ -1461,7 +1462,7 @@ describe('vaultsSecretsMkdir', () => {
       metadata: { options: { recursive: true } },
     });
     await writer.close();
-
+    // Check if the operation concluded as expected
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
     }
@@ -1476,13 +1477,15 @@ describe('vaultsSecretsMkdir', () => {
     const vaultId = await vaultManager.createVault(vaultName);
     const encodeVaultId = vaultsUtils.encodeVaultId(vaultId);
     const dirPath = 'dir/dir1/dir2';
+    // Attempt to make directories
     const response = await rpcClient.methods.vaultsSecretsMkdir();
     const writer = response.writable.getWriter();
     await writer.write({ nameOrId: encodeVaultId, dirName: dirPath });
     await writer.close();
+    // Check if the operation concluded as expected
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      if (data.type !== 'error') utils.never();
+      if (data.type !== 'error') utils.never("Type is asserted to be 'error'");
       expect(data.code).toEqual('ENOENT');
       expect(data.reason).toEqual(dirPath);
     }
@@ -1543,17 +1546,21 @@ describe('vaultsSecretsMkdir', () => {
     // Attempt to make directories
     const response = await rpcClient.methods.vaultsSecretsMkdir();
     const writer = response.writable.getWriter();
-    await writer.write({ nameOrId: vaultIdEncoded1, dirName: dirPath1 });
-    await writer.write({ nameOrId: vaultIdEncoded2, dirName: dirPath2 });
     await writer.write({ nameOrId: vaultIdEncoded1, dirName: dirPath3 });
+    await writer.write({ nameOrId: vaultIdEncoded2, dirName: dirPath2 });
+    await writer.write({ nameOrId: vaultIdEncoded1, dirName: dirPath1 });
     await writer.close();
     // Check if the operation concluded as expected
+    let successCount = 0;
     for await (const data of response.readable) {
       if (data.type === 'error') {
         expect(data.code).toEqual('ENOENT');
         expect(data.reason).toEqual(dirPath3);
+      } else {
+        successCount++;
       }
     }
+    expect(successCount).toEqual(2);
     await vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -1585,7 +1592,7 @@ describe('vaultsSecretsMkdir', () => {
     // Check if the operation concluded as expected
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      if (data.type !== 'error') utils.never();
+      if (data.type !== 'error') utils.never("Type is asserted to be 'error'");
       expect(data.code).toEqual('EEXIST');
       expect(data.reason).toEqual(dirPath);
     }
@@ -1728,7 +1735,9 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      if (data.type !== 'success') utils.never();
+      if (data.type !== 'success') {
+        utils.never("Type is asserted to be 'success'");
+      }
       expect(data.secretContent).toEqual(secretContent);
     }
   });
@@ -1747,7 +1756,7 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      if (data.type !== 'error') utils.never();
+      if (data.type !== 'error') utils.never("Type is asserted to be 'error'");
       expect(data.code).toEqual('ENOENT');
       expect(data.reason).toEqual(secretName);
     }
@@ -1773,7 +1782,7 @@ describe('vaultsSecretsCat', () => {
     // Read response
     for await (const data of response.readable) {
       expect(data.type).toEqual('error');
-      if (data.type !== 'error') utils.never();
+      if (data.type !== 'error') utils.never("Type is asserted to be 'error'");
       expect(data.code).toEqual('EISDIR');
       expect(data.reason).toEqual(secretName);
     }
@@ -1803,7 +1812,9 @@ describe('vaultsSecretsCat', () => {
     let totalContent = '';
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      if (data.type !== 'success') utils.never();
+      if (data.type !== 'success') {
+        utils.never("Type is asserted to be 'success'");
+      }
       totalContent += data.secretContent;
     }
     expect(totalContent).toEqual(`${secretContent1}${secretContent2}`);
@@ -1845,7 +1856,9 @@ describe('vaultsSecretsCat', () => {
     let totalContent = '';
     for await (const data of response.readable) {
       expect(data.type).toEqual('success');
-      if (data.type !== 'success') utils.never();
+      if (data.type !== 'success') {
+        utils.never("Type is asserted to be 'success'");
+      }
       totalContent += data.secretContent;
     }
     expect(totalContent).toEqual(
@@ -2397,7 +2410,7 @@ describe('vaultsSecretsRemove', () => {
     for await (const data of response.readable) {
       loopRun = true;
       expect(data.type).toStrictEqual('error');
-      if (data.type !== 'error') utils.never();
+      if (data.type !== 'error') utils.never("Type is asserted to be 'error'");
       expect(data.code).toStrictEqual('EINVAL');
     }
     // Check

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -70,6 +70,7 @@ import * as keysUtils from '@/keys/utils';
 import * as nodesUtils from '@/nodes/utils';
 import * as vaultsUtils from '@/vaults/utils';
 import * as vaultsErrors from '@/vaults/errors';
+import * as clientErrors from '@/client/errors';
 import * as networkUtils from '@/network/utils';
 import * as utils from '@/utils';
 import * as testsUtils from '../../utils';
@@ -2356,6 +2357,80 @@ describe('vaultsSecretsRemove', () => {
       recursive: true,
     });
   });
+  test('fails when header is not sent', async () => {
+    // Write paths
+    const response = await rpcClient.methods.vaultsSecretsRemove();
+    const writer = response.writable.getWriter();
+    // Not sending the header message
+    // Content messages
+    await writer.write({
+      type: 'SecretIdentifierMessage',
+      nameOrId: 'invalid',
+      secretName: 'invalid',
+    });
+    await writer.close();
+    // Read response
+    const consumeP = async () => {
+      for await (const _ of response.readable) {
+        // Consume values
+      }
+    };
+    await testsUtils.expectRemoteError(
+      consumeP(),
+      clientErrors.ErrorClientInvalidHeader,
+    );
+  });
+  test('fails when only the header is sent', async () => {
+    const vaultId = await vaultManager.createVault('test-vault');
+    const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
+    // Write paths
+    const response = await rpcClient.methods.vaultsSecretsRemove();
+    const writer = response.writable.getWriter();
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    // Not sending the content messages
+    await writer.close();
+    // Read response
+    const consumeP = async () => {
+      for await (const _ of response.readable) {
+        // Consume values
+      }
+    };
+    await testsUtils.expectRemoteError(
+      consumeP(),
+      clientErrors.ErrorClientProtocolError,
+    );
+  });
+  test('fails when the header is sent multiple times', async () => {
+    const vaultId = await vaultManager.createVault('test-vault');
+    const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
+    // Write paths
+    const response = await rpcClient.methods.vaultsSecretsRemove();
+    const writer = response.writable.getWriter();
+    // Header message
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    await writer.write({
+      type: 'VaultNamesHeaderMessage',
+      vaultNames: [vaultIdEncoded],
+    });
+    await writer.close();
+    // Read response
+    const consumeP = async () => {
+      for await (const _ of response.readable) {
+        // Consume values
+      }
+    };
+    await testsUtils.expectRemoteError(
+      consumeP(),
+      clientErrors.ErrorClientProtocolError,
+    );
+  });
   test('fails with invalid vault name', async () => {
     // Write paths
     const response = await rpcClient.methods.vaultsSecretsRemove();
@@ -2374,7 +2449,9 @@ describe('vaultsSecretsRemove', () => {
     await writer.close();
     // Read response
     const consumeP = async () => {
-      for await (const _ of response.readable);
+      for await (const _ of response.readable) {
+        // Consume values
+      }
     };
     await testsUtils.expectRemoteError(
       consumeP(),

--- a/tests/git/utils.ts
+++ b/tests/git/utils.ts
@@ -90,7 +90,8 @@ type NegotiationTestData =
  * @param rest - Random buffer data to be appended to the end to simulate more lines in the stream.
  */
 function generateGitNegotiationLine(data: NegotiationTestData, rest: Buffer) {
-  switch (data.type) {
+  const type = data.type;
+  switch (type) {
     case 'want': {
       // Generate a `want` line that includes `want`, the `objectId` and capabilities
       const line = Buffer.concat([
@@ -123,9 +124,8 @@ function generateGitNegotiationLine(data: NegotiationTestData, rest: Buffer) {
       // Generate an empty buffer to simulate the stream running out of data to process
       return Buffer.alloc(0);
     default:
-      // @ts-ignore: if we're here then data isn't the type we expect
       utils.never(
-        `data.type must be "want", "have", "SEPARATOR", "done", "none", got "${data.type}"`,
+        `data.type must be "want", "have", "SEPARATOR", "done", "none", got "${type}"`,
       );
   }
 }

--- a/tests/vaults/VaultInternal.test.ts
+++ b/tests/vaults/VaultInternal.test.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import { DB } from '@matrixai/db';
+import { withF } from '@matrixai/resources';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { EncryptedFS } from 'encryptedfs';
 import git from 'isomorphic-git';
@@ -491,6 +492,8 @@ describe('VaultInternal', () => {
     expect(vaultInterface.writeG).toBeTruthy();
     expect(vaultInterface.readF).toBeTruthy();
     expect(vaultInterface.readG).toBeTruthy();
+    expect(vaultInterface.acquireRead).toBeTruthy();
+    expect(vaultInterface.acquireWrite).toBeTruthy();
     expect(vaultInterface.log).toBeTruthy();
     expect(vaultInterface.version).toBeTruthy();
 
@@ -872,6 +875,82 @@ describe('VaultInternal', () => {
     ]);
     expect(finished.length).toBe(4);
     await releaseRead();
+  });
+  test('can acquire a read resource', async () => {
+    await vault.writeF(async (efs) => {
+      await efs.writeFile(secret1.name, secret1.content);
+    });
+    const acquireRead = vault.acquireRead();
+    await withF([acquireRead], async ([efs]) => {
+      const content = await efs.readFile(secret1.name);
+      expect(content.toString()).toEqual(secret1.content);
+    });
+  });
+  test('acquiring read resource respects locking', async () => {
+    const lock = vault.getLock();
+    const [releaseWrite] = await lock.write()();
+    let finished = false;
+    const readP = withF([vault.acquireRead()], async () => {
+      finished = true;
+    });
+    await sleep(waitDelay);
+    expect(finished).toBe(false);
+    await releaseWrite();
+    await readP;
+    expect(finished).toBe(true);
+  });
+  test('acquiring read resource allows concurrency', async () => {
+    const lock = vault.getLock();
+    const [releaseRead] = await lock.read()();
+    const finished: Array<boolean> = [];
+    const read1P = withF([vault.acquireRead()], async () => {
+      finished.push(true);
+    });
+    const read2P = withF([vault.acquireRead()], async () => {
+      finished.push(true);
+    });
+    const read3P = withF([vault.acquireRead()], async () => {
+      finished.push(true);
+    });
+    await Promise.all([read1P, read2P, read3P]);
+    expect(finished.length).toBe(3);
+    await releaseRead();
+  });
+  test('can acquire a write resource', async () => {
+    const acquireWrite = vault.acquireWrite();
+    await withF([acquireWrite], async ([efs]) => {
+      await efs.writeFile(secret1.name, secret1.content);
+    });
+    await vault.readF(async (efs) => {
+      const content = await efs.readFile(secret1.name);
+      expect(content.toString()).toEqual(secret1.content);
+    });
+  });
+  test('acquiring write resource respects write locking', async () => {
+    const lock = vault.getLock();
+    const [releaseWrite] = await lock.write()();
+    let finished = false;
+    const writeP = withF([vault.acquireWrite()], async () => {
+      finished = true;
+    });
+    await sleep(waitDelay);
+    expect(finished).toBe(false);
+    await releaseWrite();
+    await writeP;
+    expect(finished).toBe(true);
+  });
+  test('acquiring write resource respects read locking', async () => {
+    const lock = vault.getLock();
+    const [releaseRead] = await lock.read()();
+    let finished = false;
+    const writeP = withF([vault.acquireWrite()], async () => {
+      finished = true;
+    });
+    await sleep(waitDelay);
+    expect(finished).toBe(false);
+    await releaseRead();
+    await writeP;
+    expect(finished).toBe(true);
   });
   // Life-cycle
   test('can create with CreateVaultInternal', async () => {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

For handlers like `VaultsSecretsCopy` and `VaultsSecretsMove`, we need to acquire a transaction across multiple vaults. This allows for all the given operations to be completed in a single transaction, avoiding polluting the commit space.

This PR creates such pattern, to acquire the resources from a vault dynamically in a way which works across multiple vaults at the same time.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #821 (FIX ENG-423)
* Fixes #837 (FIX ENG-450)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Add `VaultInternal.acquireRead`
- [x] 2. Add `VaultInternal.acquireWrite`
- [x] 3. Add tests
- [x] 4. Update `VaultsSecretsRemove` to use this instead of grouping paths by vault name.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
