### PR TITLE
Resolving transaction conflicts in the discovery domain

### DIFF
--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -309,6 +309,7 @@ class Discovery {
       }
     }
     await Promise.all(taskPromises);
+    this.logger.info(`Stopped all tasks for ${this.constructor.name}`);
     this.taskManager.deregisterHandler(this.discoverVertexHandlerId);
     this.taskManager.deregisterHandler(this.checkRediscoveryHandlerId);
     this.logger.info(`Stopped ${this.constructor.name}`);

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -308,7 +308,7 @@ class NodeConnection {
       logger: logger.getChild(RPCClient.name),
     });
     if (validatedNodeId == null) {
-      never(`connection validated but no valid NodeId was returned`);
+      never('connection validated but no valid NodeId was returned');
     }
     // Obtaining remote node ID from certificate chain. It should always exist in the chain if validated.
     //  This may de different from the NodeId we validated it as if it renewed at some point.


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

Occasionally, a `ErrorDBTransactionConflict` is omitted from a background task `checkForRediscoveryHandler`. This should be properly locking a transaction and concurrent modification should be impossible.

This PR aims to figure out and eradicate the cause for this warning.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to https://github.com/MatrixAI/Polykey-CLI/issues/353 (REF ENG-511)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [ ] 1. Resolve `ErrorDBTransactionConflict` in `Discovery.checkForRediscoveryHandler`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
