### PR TITLE
parameterized `NodeConnectionManager` client manifest.

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -9,6 +9,7 @@ import type {
 import type { PolykeyWorkerManager } from './workers/types.js';
 import type { TLSConfig } from './network/types.js';
 import type { NodeAddress, NodeId, SeedNodes } from './nodes/types.js';
+import type { AgentClientManifest } from './nodes/agent/callers/index.js';
 import path from 'node:path';
 import process from 'process';
 import Logger from '@matrixai/logger';
@@ -45,6 +46,7 @@ import * as workersUtils from './workers/utils.js';
 import * as clientMiddleware from './client/middleware.js';
 import clientServerManifest from './client/handlers/index.js';
 import agentServerManifest from './nodes/agent/handlers/index.js';
+import manifestClient from './nodes/agent/callers/index.js';
 
 interface PolykeyAgent extends createDestroyStartStop.CreateDestroyStartStop {}
 @createDestroyStartStop.CreateDestroyStartStop(
@@ -177,7 +179,9 @@ class PolykeyAgent {
     let gestaltGraph: GestaltGraph | undefined;
     let identitiesManager: IdentitiesManager | undefined;
     let nodeGraph: NodeGraph | undefined;
-    let nodeConnectionManager: NodeConnectionManager | undefined;
+    let nodeConnectionManager:
+      | NodeConnectionManager<AgentClientManifest>
+      | undefined;
     let nodeManager: NodeManager | undefined;
     let discovery: Discovery | undefined;
     let notificationsManager: NotificationsManager | undefined;
@@ -286,6 +290,7 @@ class PolykeyAgent {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig,
+        rpcClientManifest: manifestClient,
         connectionFindConcurrencyLimit:
           optionsDefaulted.nodes.connectionFindConcurrencyLimit,
         connectionFindLocalTimeoutTime:
@@ -469,7 +474,7 @@ class PolykeyAgent {
   public readonly gestaltGraph: GestaltGraph;
   public readonly nodeGraph: NodeGraph;
   public readonly taskManager: TaskManager;
-  public readonly nodeConnectionManager: NodeConnectionManager;
+  public readonly nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   public readonly nodeManager: NodeManager;
   public readonly discovery: Discovery;
   public readonly vaultManager: VaultManager;
@@ -540,7 +545,7 @@ class PolykeyAgent {
     gestaltGraph: GestaltGraph;
     nodeGraph: NodeGraph;
     taskManager: TaskManager;
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     nodeManager: NodeManager;
     discovery: Discovery;
     vaultManager: VaultManager;

--- a/src/audit/Audit.ts
+++ b/src/audit/Audit.ts
@@ -12,6 +12,7 @@ import type { AuditEventId } from '../ids/types.js';
 import type NodeConnectionManager from '../nodes/NodeConnectionManager.js';
 import type Discovery from '../discovery/Discovery.js';
 import type { AbstractEvent } from '@matrixai/events';
+import type { AgentClientManifest } from '../nodes/agent/callers/index.js';
 import Logger from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import { createDestroyStartStop } from '@matrixai/async-init';
@@ -45,7 +46,7 @@ class Audit {
     fresh = false,
   }: {
     db: DB;
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     discovery: Discovery;
     logger?: Logger;
     fresh?: boolean;
@@ -59,7 +60,7 @@ class Audit {
 
   protected logger: Logger;
   protected db: DB;
-  protected nodeConnectionManager: NodeConnectionManager;
+  protected nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   protected discovery: Discovery;
 
   protected eventHandlerMap: Map<
@@ -86,7 +87,7 @@ class Audit {
     logger,
   }: {
     db: DB;
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     discovery: Discovery;
     logger: Logger;
   }) {

--- a/src/client/handlers/NodesListConnections.ts
+++ b/src/client/handlers/NodesListConnections.ts
@@ -6,12 +6,13 @@ import type {
 import type NodeConnectionManager from '../../nodes/NodeConnectionManager.js';
 import type { ContextTimed } from '@matrixai/contexts';
 import type { JSONValue } from '@matrixai/rpc';
+import type { AgentClientManifest } from '../../nodes/agent/callers/index.js';
 import { ServerHandler } from '@matrixai/rpc';
 import * as nodesUtils from '../../nodes/utils.js';
 
 class NodesListConnections extends ServerHandler<
   {
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   },
   ClientRPCRequestParams,
   ClientRPCResponseResult<NodeConnectionMessage>
@@ -25,7 +26,7 @@ class NodesListConnections extends ServerHandler<
     const {
       nodeConnectionManager,
     }: {
-      nodeConnectionManager: NodeConnectionManager;
+      nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     } = this.container;
     const connections = nodeConnectionManager.listConnections();
     for (const connection of connections) {

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -15,6 +15,7 @@ import type NodeGraph from '../../nodes/NodeGraph.js';
 import type VaultManager from '../../vaults/VaultManager.js';
 import type PolykeyAgent from '../../PolykeyAgent.js';
 import type { FileSystem } from '../../types.js';
+import type { AgentClientManifest } from '../../nodes/agent/callers/index.js';
 import AgentLockAll from './AgentLockAll.js';
 import AgentStatus from './AgentStatus.js';
 import AgentStop from './AgentStop.js';
@@ -108,7 +109,7 @@ const serverManifest = (container: {
   audit: Audit;
   notificationsManager: NotificationsManager;
   nodeManager: NodeManager;
-  nodeConnectionManager: NodeConnectionManager;
+  nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   nodeGraph: NodeGraph;
   vaultManager: VaultManager;
   fs: FileSystem;

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -2,6 +2,7 @@ import type { X509Certificate } from '@peculiar/x509';
 import type { ContextTimed, ContextTimedInput } from '@matrixai/contexts';
 import type { PromiseCancellable } from '@matrixai/async-cancellable';
 import type { QUICSocket, QUICConnection } from '@matrixai/quic';
+import type { ClientManifest } from '@matrixai/rpc';
 import type { Host, Hostname, Port, TLSConfig } from '../network/types.js';
 import type { Certificate } from '../keys/types.js';
 import type { NodeId } from './types.js';
@@ -31,12 +32,14 @@ type AgentClientManifest = typeof agentClientManifest;
 /**
  * Encapsulates the unidirectional client-side connection of one node to another.
  */
-interface NodeConnection extends createDestroy.CreateDestroy {}
+// eslint-disable-next-line
+interface NodeConnection<Manifest extends ClientManifest>
+  extends createDestroy.CreateDestroy {}
 @createDestroy.CreateDestroy({
   eventDestroy: nodesEvents.EventNodeConnectionDestroy,
   eventDestroyed: nodesEvents.EventNodeConnectionDestroyed,
 })
-class NodeConnection {
+class NodeConnection<Manifest extends ClientManifest> {
   /**
    * Hostname is defined if the target's host was resolved from this hostname
    * Undefined if a Host was directly provided
@@ -60,7 +63,7 @@ class NodeConnection {
   public readonly quicClient: QUICClient | undefined;
   public readonly quicConnection: QUICConnection;
   public readonly connectionId: string;
-  public readonly rpcClient: RPCClient<AgentClientManifest>;
+  public readonly rpcClient: RPCClient<Manifest>;
 
   /**
    * Dispatches a `EventNodeConnectionClose` in response to any `NodeConnection`
@@ -161,7 +164,7 @@ class NodeConnection {
     }
   };
 
-  static createNodeConnection(
+  static createNodeConnection<Manifest extends ClientManifest>(
     {
       targetNodeIds,
       targetHost,
@@ -186,16 +189,18 @@ class NodeConnection {
       connectionInitialMaxStreamsBidi?: number;
       connectionInitialMaxStreamsUni?: number;
       quicSocket?: QUICSocket;
-      manifest: AgentClientManifest;
+      manifest: Manifest;
       logger?: Logger;
     },
     ctx?: Partial<ContextTimedInput>,
-  ): PromiseCancellable<NodeConnection>;
+  ): PromiseCancellable<NodeConnection<Manifest>>;
   @decorators.timedCancellable(
     true,
     config.defaultsSystem.nodesConnectionConnectTimeoutTime,
   )
-  static async createNodeConnection(
+  static async createNodeConnection<
+    Manifest extends ClientManifest = AgentClientManifest,
+  >(
     {
       targetNodeIds,
       targetHost,
@@ -218,7 +223,7 @@ class NodeConnection {
       targetPort: Port;
       targetHostname?: Hostname;
       tlsConfig: TLSConfig;
-      manifest: AgentClientManifest;
+      manifest: Manifest;
       connectionKeepAliveIntervalTime?: number;
       connectionKeepAliveTimeoutTime?: number;
       connectionInitialMaxStreamsBidi?: number;
@@ -227,7 +232,7 @@ class NodeConnection {
       logger?: Logger;
     },
     @decorators.context ctx: ContextTimed,
-  ): Promise<NodeConnection> {
+  ): Promise<NodeConnection<Manifest>> {
     logger.info(`Creating forward ${this.name}`);
     // Checking if attempting to connect to a wildcard IP
     if (networkUtils.isHostWildcard(targetHost)) {
@@ -295,7 +300,7 @@ class NodeConnection {
       quicEvents.EventQUICConnectionStream.name,
       throwFunction,
     );
-    const rpcClient = new RPCClient<AgentClientManifest>({
+    const rpcClient = new RPCClient<Manifest>({
       manifest,
       middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(),
       streamFactory: async () => quicConnection.newStream(),
@@ -318,7 +323,7 @@ class NodeConnection {
         quicConnection.remoteHost
       }:${quicConnection.remotePort}]`,
     );
-    const nodeConnection = new this({
+    const nodeConnection = new this<Manifest>({
       validatedNodeId,
       nodeId,
       host: targetHost,
@@ -368,7 +373,7 @@ class NodeConnection {
     return nodeConnection;
   }
 
-  static createNodeConnectionReverse({
+  static createNodeConnectionReverse<Manifest extends ClientManifest>({
     certChain,
     nodeId,
     quicConnection,
@@ -378,12 +383,12 @@ class NodeConnection {
     certChain: Array<Certificate>;
     nodeId: NodeId;
     quicConnection: QUICConnection;
-    manifest: AgentClientManifest;
+    manifest: Manifest;
     logger?: Logger;
-  }): NodeConnection {
+  }): NodeConnection<Manifest> {
     logger.info(`Creating reverse ${this.name}`);
     // Creating RPCClient
-    const rpcClient = new RPCClient<AgentClientManifest>({
+    const rpcClient = new RPCClient<Manifest>({
       manifest,
       middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(),
       streamFactory: async (_ctx) => {
@@ -393,7 +398,7 @@ class NodeConnection {
       logger: logger.getChild(RPCClient.name),
     });
     // Creating NodeConnection
-    const nodeConnection = new this({
+    const nodeConnection = new this<Manifest>({
       validatedNodeId: nodeId,
       nodeId: nodeId,
       localHost: quicConnection.localHost as unknown as Host,
@@ -467,7 +472,7 @@ class NodeConnection {
     quicClient?: QUICClient;
     quicConnection: QUICConnection;
     connectionId: string;
-    rpcClient: RPCClient<AgentClientManifest>;
+    rpcClient: RPCClient<Manifest>;
     logger: Logger;
   }) {
     this.validatedNodeId = validatedNodeId;
@@ -544,7 +549,7 @@ class NodeConnection {
   /**
    * Gets RPCClient for this node connection
    */
-  public getClient(): RPCClient<AgentClientManifest> {
+  public getClient(): RPCClient<Manifest> {
     return this.rpcClient;
   }
 }

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -1,7 +1,11 @@
 import type { ResourceAcquire } from '@matrixai/resources';
 import type { ContextTimed, ContextTimedInput } from '@matrixai/contexts';
 import type { QUICConnection } from '@matrixai/quic';
-import type { JSONRPCRequest, JSONRPCResponse } from '@matrixai/rpc';
+import type {
+  ClientManifest,
+  JSONRPCRequest,
+  JSONRPCResponse,
+} from '@matrixai/rpc';
 import type {
   AuthenticateNetworkForwardCallback,
   AuthenticateNetworkReverseCallback,
@@ -13,6 +17,7 @@ import type {
   SuccessMessage,
 } from './agent/types.js';
 import type { AgentServerManifest } from './agent/handlers/index.js';
+import type { AgentClientManifestCore } from './agent/callers/index.js';
 import type KeyRing from '../keys/KeyRing.js';
 import type { CertificatePEM } from '../keys/types.js';
 import type {
@@ -45,7 +50,6 @@ import { decorators } from '@matrixai/contexts';
 import { Semaphore } from '@matrixai/async-locks';
 import { PromiseCancellable } from '@matrixai/async-cancellable';
 import NodeConnection from './NodeConnection.js';
-import agentClientManifest from './agent/callers/index.js';
 import * as nodesUtils from './utils.js';
 import * as nodesErrors from './errors.js';
 import * as nodesEvents from './events.js';
@@ -56,8 +60,8 @@ import * as utils from '../utils/index.js';
 import RateLimiter from '../utils/ratelimiter/RateLimiter.js';
 import config from '../config.js';
 
-type ConnectionAndTimer = {
-  connection: NodeConnection;
+type ConnectionAndTimer<Manifest extends ClientManifest> = {
+  connection: NodeConnection<Manifest>;
   timer: Timer | null;
   usageCount: number;
 };
@@ -68,9 +72,9 @@ enum AuthenticatingState {
   FAIL = 3,
 }
 
-type ConnectionsEntry = {
+type ConnectionsEntry<Manifest extends ClientManifest> = {
   activeConnection: string;
-  connections: Record<string, ConnectionAndTimer>;
+  connections: Record<string, ConnectionAndTimer<Manifest>>;
   // This tracks the authentication state machine
   authenticatedForward: AuthenticatingState;
   authenticatedReverse: AuthenticatingState;
@@ -121,14 +125,16 @@ const rpcMethodsWhitelist = ['nodesAuthenticateConnection'];
  * The NodeConnectionManager encapsulates `QUICServer`.
  * While the NodeConnection encapsulates `QUICClient`.
  */
-interface NodeConnectionManager extends startStop.StartStop {}
+// eslint-disable-next-line
+interface NodeConnectionManager<Manifest extends AgentClientManifestCore>
+  extends startStop.StartStop {}
 @startStop.StartStop({
   eventStart: nodesEvents.EventNodeConnectionManagerStart,
   eventStarted: nodesEvents.EventNodeConnectionManagerStarted,
   eventStop: nodesEvents.EventNodeConnectionManagerStop,
   eventStopped: nodesEvents.EventNodeConnectionManagerStopped,
 })
-class NodeConnectionManager {
+class NodeConnectionManager<Manifest extends AgentClientManifestCore> {
   /**
    * Alpha constant for kademlia
    * The number of the closest nodes to contact initially
@@ -256,9 +262,11 @@ class NodeConnectionManager {
    * A nodeIdString is used for the key here since
    * NodeIds can't be used to properly retrieve a value from the map.
    */
-  protected connections: Map<NodeIdString, ConnectionsEntry> = new Map();
+  protected connections: Map<NodeIdString, ConnectionsEntry<Manifest>> =
+    new Map();
 
   protected rpcServer: RPCServer;
+  protected rpcClientManifest: Manifest;
 
   /**
    * Dispatches a `EventNodeConnectionManagerClose` in response to any `NodeConnectionManager`
@@ -293,7 +301,7 @@ class NodeConnectionManager {
     evt: nodesEvents.EventNodeConnectionStream,
   ) => {
     if (evt.target == null) utils.never('target should be defined here');
-    const nodeConnection = evt.target as NodeConnection;
+    const nodeConnection = evt.target as NodeConnection<Manifest>;
     const connectionId = nodeConnection.connectionId;
     const nodeId = nodeConnection.validatedNodeId as NodeId;
     const nodeIdString = nodeId.toString() as NodeIdString;
@@ -332,7 +340,7 @@ class NodeConnectionManager {
     evt: nodesEvents.EventNodeConnectionDestroyed,
   ) => {
     if (evt.target == null) utils.never('target should be defined here');
-    const nodeConnection = evt.target as NodeConnection;
+    const nodeConnection = evt.target as NodeConnection<Manifest>;
     const nodeId = nodeConnection.validatedNodeId as NodeId;
     const connectionId = nodeConnection.connectionId;
     await this.destroyConnection(nodeId, true, connectionId);
@@ -417,6 +425,7 @@ class NodeConnectionManager {
   public constructor({
     keyRing,
     tlsConfig,
+    rpcClientManifest,
     connectionFindConcurrencyLimit = config.defaultsSystem
       .nodesConnectionFindConcurrencyLimit,
     connectionGetClosestLimit = config.defaultsSystem.nodesGraphBucketLimit,
@@ -446,6 +455,7 @@ class NodeConnectionManager {
   }: {
     keyRing: KeyRing;
     tlsConfig: TLSConfig;
+    rpcClientManifest: Manifest;
     connectionFindConcurrencyLimit?: number;
     connectionGetClosestLimit?: number;
     connectionFindLocalTimeoutTime?: number;
@@ -466,6 +476,7 @@ class NodeConnectionManager {
     this.logger = logger ?? new Logger(this.constructor.name);
     this.keyRing = keyRing;
     this.tlsConfig = tlsConfig;
+    this.rpcClientManifest = rpcClientManifest;
     this.connectionFindConcurrencyLimit = connectionFindConcurrencyLimit;
     this.connectionGetClosestLimit = connectionGetClosestLimit;
     this.connectionFindLocalTimeoutTime = connectionFindLocalTimeoutTime;
@@ -699,7 +710,7 @@ class NodeConnectionManager {
    */
   protected acquireConnectionInternal(
     targetNodeId: NodeId,
-  ): ResourceAcquire<NodeConnection> {
+  ): ResourceAcquire<NodeConnection<Manifest>> {
     if (this.keyRing.getNodeId().equals(targetNodeId)) {
       this.logger.warn('Attempting connection to our own NodeId');
     }
@@ -777,7 +788,7 @@ class NodeConnectionManager {
   public acquireConnection(
     targetNodeId: NodeId,
     ctx: ContextTimed,
-  ): ResourceAcquire<NodeConnection> {
+  ): ResourceAcquire<NodeConnection<Manifest>> {
     return async () => {
       await this.isAuthenticatedP(targetNodeId, ctx);
       return await this.acquireConnectionInternal(targetNodeId)();
@@ -796,13 +807,13 @@ class NodeConnectionManager {
   public async withConnF<T>(
     targetNodeId: NodeId,
     ctx: Partial<ContextTimedInput> | undefined,
-    f: (conn: NodeConnection) => Promise<T>,
+    f: (conn: NodeConnection<Manifest>) => Promise<T>,
   ): Promise<T>;
   @decorators.timedCancellable(true)
   public async withConnF<T>(
     targetNodeId: NodeId,
     @decorators.context ctx: ContextTimed,
-    f: (conn: NodeConnection) => Promise<T>,
+    f: (conn: NodeConnection<Manifest>) => Promise<T>,
   ): Promise<T> {
     return await withF(
       [this.acquireConnection(targetNodeId, ctx)],
@@ -824,14 +835,14 @@ class NodeConnectionManager {
   public withConnG<T, TReturn, TNext>(
     targetNodeId: NodeId,
     ctx: Partial<ContextTimedInput> | undefined,
-    g: (conn: NodeConnection) => AsyncGenerator<T, TReturn, TNext>,
+    g: (conn: NodeConnection<Manifest>) => AsyncGenerator<T, TReturn, TNext>,
   ): AsyncGenerator<T, TReturn, TNext>;
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timed()
   public async *withConnG<T, TReturn, TNext>(
     targetNodeId: NodeId,
     @decorators.context ctx: ContextTimed,
-    g: (conn: NodeConnection) => AsyncGenerator<T, TReturn, TNext>,
+    g: (conn: NodeConnection<Manifest>) => AsyncGenerator<T, TReturn, TNext>,
   ): AsyncGenerator<T, TReturn, TNext> {
     const acquire = this.acquireConnection(targetNodeId, ctx);
     const [release, conn] = await acquire();
@@ -856,11 +867,11 @@ class NodeConnectionManager {
     host: Host,
     port: Port,
     ctx?: Partial<ContextTimedInput>,
-  ): PromiseCancellable<NodeConnection>;
+  ): PromiseCancellable<NodeConnection<Manifest>>;
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async createConnection(
@@ -868,11 +879,11 @@ class NodeConnectionManager {
     host: Host,
     port: Port,
     @decorators.context ctx: ContextTimed,
-  ): Promise<NodeConnection> {
-    const nodeConnection = await NodeConnection.createNodeConnection(
+  ): Promise<NodeConnection<Manifest>> {
+    const nodeConnection = await NodeConnection.createNodeConnection<Manifest>(
       {
         targetNodeIds: nodeIds,
-        manifest: agentClientManifest,
+        manifest: this.rpcClientManifest,
         targetHost: host,
         targetPort: port,
         tlsConfig: this.tlsConfig,
@@ -924,18 +935,18 @@ class NodeConnectionManager {
     nodeIds: Array<NodeId>,
     addresses: Array<[Host, Port]>,
     ctx?: Partial<ContextTimedInput>,
-  ): PromiseCancellable<NodeConnection>;
+  ): PromiseCancellable<NodeConnection<Manifest>>;
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async createConnectionMultiple(
     nodeIds: Array<NodeId>,
     addresses: Array<[Host, Port]>,
     @decorators.context ctx: ContextTimed,
-  ): Promise<NodeConnection> {
+  ): Promise<NodeConnection<Manifest>> {
     // Setting up intermediate signal
     const abortControllerMultiConn = new AbortController();
     const handleAbort = () => {
@@ -979,18 +990,18 @@ class NodeConnectionManager {
     nodeIdTarget: NodeId,
     nodeIdSignaller: NodeId,
     ctx?: Partial<ContextTimedInput>,
-  ): PromiseCancellable<NodeConnection>;
+  ): PromiseCancellable<NodeConnection<Manifest>>;
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async createConnectionPunch(
     nodeIdTarget: NodeId,
     nodeIdSignaller: NodeId,
     @decorators.context ctx: ContextTimed,
-  ): Promise<NodeConnection> {
+  ): Promise<NodeConnection<Manifest>> {
     // Get the signaller node from the existing connections
     if (!this.hasConnection(nodeIdSignaller)) {
       throw new nodesErrors.ErrorNodeConnectionManagerConnectionNotFound();
@@ -1047,8 +1058,8 @@ class NodeConnectionManager {
    */
   protected addConnection(
     nodeId: NodeId,
-    nodeConnection: NodeConnection,
-  ): ConnectionAndTimer {
+    nodeConnection: NodeConnection<Manifest>,
+  ): ConnectionAndTimer<Manifest> {
     const nodeIdString = nodeId.toString() as NodeIdString;
     const connectionId = nodeConnection.connectionId;
     // Setting up events
@@ -1065,7 +1076,7 @@ class NodeConnectionManager {
 
     // Creating TTL timeout.
     // Add to map
-    const newConnAndTimer: ConnectionAndTimer = {
+    const newConnAndTimer: ConnectionAndTimer<Manifest> = {
       connection: nodeConnection,
       timer: null,
       usageCount: 0,
@@ -1141,7 +1152,9 @@ class NodeConnectionManager {
   /**
    * Gets the existing active connection for the target node
    */
-  public getConnection(nodeId: NodeId): ConnectionAndTimer | undefined {
+  public getConnection(
+    nodeId: NodeId,
+  ): ConnectionAndTimer<Manifest> | undefined {
     const nodeIdString = nodeId.toString() as NodeIdString;
     const connectionsEntry = this.connections.get(nodeIdString);
     if (connectionsEntry == null) return;
@@ -1263,17 +1276,18 @@ class NodeConnectionManager {
     }
     const nodeId = keysUtils.certNodeId(certChain[0]);
     if (nodeId == null) utils.never('failed to get NodeId from certificate');
-    const nodeConnectionNew = NodeConnection.createNodeConnectionReverse({
-      nodeId,
-      certChain,
-      manifest: agentClientManifest,
-      quicConnection: quicConnection,
-      logger: this.logger.getChild(
-        `${NodeConnection.name}Reverse [${nodesUtils.encodeNodeId(nodeId)}@${
-          quicConnection.remoteHost
-        }:${quicConnection.remotePort}]`,
-      ),
-    });
+    const nodeConnectionNew =
+      NodeConnection.createNodeConnectionReverse<Manifest>({
+        nodeId,
+        certChain,
+        manifest: this.rpcClientManifest,
+        quicConnection: quicConnection,
+        logger: this.logger.getChild(
+          `${NodeConnection.name}Reverse [${nodesUtils.encodeNodeId(nodeId)}@${
+            quicConnection.remoteHost
+          }:${quicConnection.remotePort}]`,
+        ),
+      });
     this.addConnection(nodeId, nodeConnectionNew);
     // Dispatch the connection event
     const connectionData: ConnectionData = {
@@ -1322,7 +1336,7 @@ class NodeConnectionManager {
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async holePunch(
@@ -1519,7 +1533,7 @@ class NodeConnectionManager {
   @startStop.ready(new nodesErrors.ErrorNodeManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async handleNodesConnectionSignalInitial(
@@ -1684,7 +1698,7 @@ class NodeConnectionManager {
   ): PromiseCancellable<void>;
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async forwardAuthenticate(
@@ -1805,7 +1819,7 @@ class NodeConnectionManager {
   ): PromiseCancellable<void>;
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async handleReverseAuthenticate(
@@ -2027,7 +2041,7 @@ class NodeConnectionManager {
   ): Promise<void>;
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<Manifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async isAuthenticatedP(

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -33,6 +33,7 @@ import type {
 import type NodeConnectionManager from './NodeConnectionManager.js';
 import type NodeGraph from './NodeGraph.js';
 import type { ServicePOJO } from '@matrixai/mdns';
+import type { AgentClientManifest } from './agent/callers/index.js';
 import { withF } from '@matrixai/resources';
 import { events as mdnsEvents, MDNS, utils as mdnsUtils } from '@matrixai/mdns';
 import Logger from '@matrixai/logger';
@@ -100,7 +101,7 @@ class NodeManager {
   protected gestaltGraph: GestaltGraph;
   protected taskManager: TaskManager;
   protected nodeGraph: NodeGraph;
-  protected nodeConnectionManager: NodeConnectionManager;
+  protected nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   protected mdnsOptions:
     | {
         groups: Array<Host>;
@@ -243,7 +244,7 @@ class NodeManager {
     );
     const successfulConnections = connectionResults.filter(
       (r) => r.status === 'fulfilled',
-    ) as Array<PromiseFulfilledResult<NodeConnection>>;
+    ) as Array<PromiseFulfilledResult<NodeConnection<AgentClientManifest>>>;
     if (successfulConnections.length === 0) {
       const failedConnectionErrors = connectionResults
         .filter((r) => r.status === 'rejected')
@@ -343,7 +344,7 @@ class NodeManager {
       groups: Array<Host>;
       port: Port;
     };
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     connectionConnectTimeoutTime?: number;
     refreshBucketDelayTime?: number;
     refreshBucketDelayJitter?: number;
@@ -459,7 +460,7 @@ class NodeManager {
   public acquireConnection(
     nodeId: NodeId,
     ctx: ContextTimed,
-  ): ResourceAcquire<NodeConnection> {
+  ): ResourceAcquire<NodeConnection<AgentClientManifest>> {
     if (this.keyRing.getNodeId().equals(nodeId)) {
       throw new nodesErrors.ErrorNodeManagerNodeIdOwn();
     }
@@ -497,13 +498,13 @@ class NodeManager {
   public async withConnF<T>(
     nodeId: NodeId,
     ctx: Partial<ContextTimedInput> | undefined,
-    f: (conn: NodeConnection) => Promise<T>,
+    f: (conn: NodeConnection<AgentClientManifest>) => Promise<T>,
   ): Promise<T>;
   @startStop.ready(new nodesErrors.ErrorNodeManagerNotRunning())
   public async withConnF<T>(
     nodeId: NodeId,
     @decorators.context ctx: ContextTimed,
-    f: (conn: NodeConnection) => Promise<T>,
+    f: (conn: NodeConnection<AgentClientManifest>) => Promise<T>,
   ): Promise<T> {
     return await withF(
       [this.acquireConnection(nodeId, ctx)],
@@ -525,14 +526,18 @@ class NodeManager {
   public withConnG<T, TReturn, TNext>(
     nodeId: NodeId,
     ctx: Partial<ContextTimedInput> | undefined,
-    g: (conn: NodeConnection) => AsyncGenerator<T, TReturn, TNext>,
+    g: (
+      conn: NodeConnection<AgentClientManifest>,
+    ) => AsyncGenerator<T, TReturn, TNext>,
   ): AsyncGenerator<T, TReturn, TNext>;
   @startStop.ready(new nodesErrors.ErrorNodeManagerNotRunning())
   @decorators.timed()
   public async *withConnG<T, TReturn, TNext>(
     nodeId: NodeId,
     @decorators.context ctx: ContextTimed,
-    g: (conn: NodeConnection) => AsyncGenerator<T, TReturn, TNext>,
+    g: (
+      conn: NodeConnection<AgentClientManifest>,
+    ) => AsyncGenerator<T, TReturn, TNext>,
   ): AsyncGenerator<T, TReturn, TNext> {
     const acquire = this.acquireConnection(nodeId, ctx);
     const [release, conn] = await acquire();
@@ -707,7 +712,7 @@ class NodeManager {
       ctx.signal.throwIfAborted();
       const isDone = await nodeConnectionsQueue.withNodeSignal(
         async (nodeIdTarget, nodeIdSignaller) => {
-          let nodeConnection: NodeConnection | undefined;
+          let nodeConnection: NodeConnection<AgentClientManifest> | undefined;
           if (
             !this.nodeConnectionManager.hasConnection(nodeIdTarget) &&
             nodeIdSignaller != null
@@ -1162,7 +1167,7 @@ class NodeManager {
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<AgentClientManifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async pingNode(
@@ -1194,7 +1199,7 @@ class NodeManager {
   @startStop.ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
   @decorators.timedCancellable(
     true,
-    (nodeConnectionManager: NodeConnectionManager) =>
+    (nodeConnectionManager: NodeConnectionManager<AgentClientManifest>) =>
       nodeConnectionManager.connectionConnectTimeoutTime,
   )
   public async pingNodeAddress(

--- a/src/nodes/agent/callers/index.ts
+++ b/src/nodes/agent/callers/index.ts
@@ -1,3 +1,4 @@
+import type { ClientManifest } from '@matrixai/rpc';
 import nodesAuthenticateConnection from './nodesAuthenticateConnection.js';
 import nodesAuditEventsGet from './nodesAuditEventsGet.js';
 import nodesClaimsGet from './nodesClaimsGet.js';
@@ -13,17 +14,23 @@ import vaultsGitInfoGet from './vaultsGitInfoGet.js';
 import vaultsGitPackGet from './vaultsGitPackGet.js';
 import vaultsScan from './vaultsScan.js';
 
+const manifestClientCore = {
+  nodesConnectionSignalFinal,
+  nodesConnectionSignalInitial,
+  nodesAuthenticateConnection,
+} satisfies ClientManifest;
+
+type AgentClientManifestCore = typeof manifestClientCore & ClientManifest;
+
 /**
  * Client manifest
  */
 const manifestClient = {
-  nodesAuthenticateConnection,
+  ...manifestClientCore,
   nodesAuditEventsGet,
   nodesClaimsGet,
   nodesClosestActiveConnectionsGet,
   nodesClosestLocalNodesGet,
-  nodesConnectionSignalFinal,
-  nodesConnectionSignalInitial,
   nodesCrossSignClaim,
   nodesClaimNetworkSign,
   nodesClaimNetworkVerify,
@@ -31,13 +38,14 @@ const manifestClient = {
   vaultsGitInfoGet,
   vaultsGitPackGet,
   vaultsScan,
-};
+} satisfies ClientManifest;
 
 type AgentClientManifest = typeof manifestClient;
 
 export default manifestClient;
 
 export {
+  manifestClientCore,
   nodesAuthenticateConnection,
   nodesAuditEventsGet,
   nodesClaimsGet,
@@ -54,4 +62,4 @@ export {
   vaultsScan,
 };
 
-export type { AgentClientManifest };
+export type { AgentClientManifestCore, AgentClientManifest };

--- a/src/nodes/agent/handlers/NodesAuthenticateConnection.ts
+++ b/src/nodes/agent/handlers/NodesAuthenticateConnection.ts
@@ -7,13 +7,14 @@ import type {
 } from '../types.js';
 import type NodeConnectionManager from '../../../nodes/NodeConnectionManager.js';
 import type { JSONValue } from '../../../types.js';
+import type { AgentClientManifest } from '../callers/index.js';
 import { DuplexHandler } from '@matrixai/rpc';
 import * as agentUtils from '../utils.js';
 import * as nodesErrors from '../../errors.js';
 
 class NodesAuthenticateConnection extends DuplexHandler<
   {
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   },
   AgentRPCRequestParams<SuccessMessage | NodesAuthenticateConnectionMessage>,
   AgentRPCResponseResult<SuccessMessage | NodesAuthenticateConnectionMessage>
@@ -33,7 +34,7 @@ class NodesAuthenticateConnection extends DuplexHandler<
     const {
       nodeConnectionManager,
     }: {
-      nodeConnectionManager: NodeConnectionManager;
+      nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     } = this.container;
 
     // Connections should always be validated

--- a/src/nodes/agent/handlers/NodesClosestActiveConnectionsGet.ts
+++ b/src/nodes/agent/handlers/NodesClosestActiveConnectionsGet.ts
@@ -8,6 +8,7 @@ import type {
 import type NodeConnectionManager from '../../NodeConnectionManager.js';
 import type { NodeId } from '../../../ids/index.js';
 import type { ActiveConnectionDataMessage } from '../types.js';
+import type { AgentClientManifest } from '../callers/index.js';
 import { ServerHandler } from '@matrixai/rpc';
 import * as utils from '../../../utils/index.js';
 import * as ids from '../../../ids/index.js';
@@ -19,7 +20,7 @@ import * as nodesUtils from '../../utils.js';
  */
 class NodesClosestActiveConnectionsGet extends ServerHandler<
   {
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   },
   AgentRPCRequestParams<NodeIdMessage>,
   AgentRPCResponseResult<ActiveConnectionDataMessage>
@@ -33,7 +34,7 @@ class NodesClosestActiveConnectionsGet extends ServerHandler<
     const {
       nodeConnectionManager,
     }: {
-      nodeConnectionManager: NodeConnectionManager;
+      nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     } = this.container;
 
     const {

--- a/src/nodes/agent/handlers/NodesConnectionSignalFinal.ts
+++ b/src/nodes/agent/handlers/NodesConnectionSignalFinal.ts
@@ -8,6 +8,7 @@ import type {
 import type { NodeId } from '../../../ids/index.js';
 import type NodeConnectionManager from '../../NodeConnectionManager.js';
 import type { Host, Port } from '../../../network/types.js';
+import type { AgentClientManifest } from '../callers/index.js';
 import { UnaryHandler } from '@matrixai/rpc';
 import { validateSync } from '../../../validation/index.js';
 import { matchSync } from '../../../utils/index.js';
@@ -18,7 +19,7 @@ import * as nodesErrors from '../../errors.js';
 
 class NodesConnectionSignalFinal extends UnaryHandler<
   {
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     logger: Logger;
   },
   AgentRPCRequestParams<HolePunchRequestMessage>,
@@ -33,7 +34,7 @@ class NodesConnectionSignalFinal extends UnaryHandler<
       nodeConnectionManager,
       logger,
     }: {
-      nodeConnectionManager: NodeConnectionManager;
+      nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
       logger: Logger;
     } = this.container;
     // Connections should always be validated

--- a/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
+++ b/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
@@ -8,6 +8,7 @@ import type { NodeId } from '../../../ids/index.js';
 import type NodeConnectionManager from '../../../nodes/NodeConnectionManager.js';
 import type { Host, Port } from '../../../network/types.js';
 import type { JSONValue } from '../../../types.js';
+import type { AgentClientManifest } from '../callers/index.js';
 import { UnaryHandler } from '@matrixai/rpc';
 import { validateSync } from '../../../validation/index.js';
 import { matchSync } from '../../../utils/index.js';
@@ -19,7 +20,7 @@ import * as ids from '../../../ids/index.js';
 
 class NodesConnectionSignalInitial extends UnaryHandler<
   {
-    nodeConnectionManager: NodeConnectionManager;
+    nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   },
   AgentRPCRequestParams<HolePunchSignalMessage>,
   AgentRPCResponseResult<AddressMessage>
@@ -32,7 +33,7 @@ class NodesConnectionSignalInitial extends UnaryHandler<
     const {
       nodeConnectionManager,
     }: {
-      nodeConnectionManager: NodeConnectionManager;
+      nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     } = this.container;
     // Connections should always be validated
     const requestingNodeId = agentUtils.nodeIdFromMeta(meta);

--- a/src/nodes/agent/handlers/index.ts
+++ b/src/nodes/agent/handlers/index.ts
@@ -9,6 +9,7 @@ import type NodeManager from '../../../nodes/NodeManager.js';
 import type NodeConnectionManager from '../../../nodes/NodeConnectionManager.js';
 import type NotificationsManager from '../../../notifications/NotificationsManager.js';
 import type VaultManager from '../../../vaults/VaultManager.js';
+import type { AgentClientManifest } from '../callers/index.js';
 import NodesAuthenticateConnection from './NodesAuthenticateConnection.js';
 import NodesAuditEventsGet from './NodesAuditEventsGet.js';
 import NodesClaimsGet from './NodesClaimsGet.js';
@@ -33,7 +34,7 @@ const manifestServer = (container: {
   nodeGraph: NodeGraph;
   acl: ACL;
   nodeManager: NodeManager;
-  nodeConnectionManager: NodeConnectionManager;
+  nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   keyRing: KeyRing;
   logger: Logger;
   notificationsManager: NotificationsManager;

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -38,7 +38,7 @@ import * as gitHttp from '../git/http.js';
 import * as nodesUtils from '../nodes/utils.js';
 import * as keysUtils from '../keys/utils/index.js';
 import { polykeyWorkerManifest } from '../workers/index.js';
-import * as utils from '#utils/index.js';
+import * as utils from '../utils/index.js';
 
 /**
  * Object map pattern for each vault.

--- a/tests/audit/Audit.test.ts
+++ b/tests/audit/Audit.test.ts
@@ -1,5 +1,6 @@
 import type { ConnectionData, Host, Port } from '#network/types.js';
 import type NodeConnectionManager from '#nodes/NodeConnectionManager.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -23,7 +24,7 @@ describe(Audit.name, () => {
 
   let dataDir: string;
   let db: DB;
-  let mockNodeConnectionManager: NodeConnectionManager;
+  let mockNodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),
@@ -38,7 +39,8 @@ describe(Audit.name, () => {
         ops: polykeyWorkerManifest,
       },
     });
-    mockNodeConnectionManager = new EventTarget() as NodeConnectionManager;
+    mockNodeConnectionManager =
+      new EventTarget() as NodeConnectionManager<AgentClientManifest>;
   });
   afterEach(async () => {
     await db.stop();

--- a/tests/client/handlers/audit.test.ts
+++ b/tests/client/handlers/audit.test.ts
@@ -4,6 +4,7 @@ import type NodeConnectionManager from '#nodes/NodeConnectionManager.js';
 import type Discovery from '#discovery/Discovery.js';
 import type { GestaltIdEncoded } from '#ids/index.js';
 import type { POJO } from '#index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -46,7 +47,7 @@ describe('auditEventGet', () => {
     }>
   >;
   let tlsConfig: TLSConfig;
-  let nodeConnectionManager: NodeConnectionManager; // Event target pretending to be discovery
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>; // Event target pretending to be discovery
   let discovery: Discovery; // Event target pretending to be discovery
 
   const handleEvent = async (evt) => {
@@ -440,7 +441,7 @@ describe('auditMetricGet', () => {
     }>
   >;
   let tlsConfig: TLSConfig;
-  let nodeConnectionManager: NodeConnectionManager; // Event target pretending to be discovery
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>; // Event target pretending to be discovery
   let discovery: Discovery; // Event target pretending to be discovery
 
   beforeEach(async () => {

--- a/tests/client/handlers/gestalts.test.ts
+++ b/tests/client/handlers/gestalts.test.ts
@@ -18,6 +18,7 @@ import type { Host } from '#network/types.js';
 import type { ClaimLinkIdentity } from '#claims/payloads/index.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
 import type { DiscoveryQueueInfo } from '#discovery/types.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -81,6 +82,7 @@ import * as gestaltsErrors from '#gestalts/errors.js';
 import * as networkUtils from '#network/utils.js';
 import * as keysUtils from '#keys/utils/index.js';
 import * as utils from '#utils/index.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('gestaltsActionsByIdentity', () => {
   const logger = new Logger('gestaltsActionsByIdentity test', LogLevel.WARN, [
@@ -393,7 +395,7 @@ describe('gestaltsDiscoveryByIdentity', () => {
   let nodeGraph: NodeGraph;
   let sigchain: Sigchain;
   let nodeManager: NodeManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let discovery: Discovery;
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
@@ -450,6 +452,7 @@ describe('gestaltsDiscoveryByIdentity', () => {
       nodeGraph,
       // @ts-ignore: TLS not needed for this test
       tlsConfig: {},
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -579,7 +582,7 @@ describe('gestaltsDiscoveryByNode', () => {
   let nodeGraph: NodeGraph;
   let sigchain: Sigchain;
   let nodeManager: NodeManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let discovery: Discovery;
 
   beforeEach(async () => {
@@ -637,6 +640,7 @@ describe('gestaltsDiscoveryByNode', () => {
       nodeGraph,
       // @ts-ignore: TLS not needed for this test
       tlsConfig: {},
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -763,7 +767,7 @@ describe('gestaltsDiscoveryQueue', () => {
   let nodeGraph: NodeGraph;
   let sigchain: Sigchain;
   let nodeManager: NodeManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let discovery: Discovery;
 
   beforeEach(async () => {
@@ -821,6 +825,7 @@ describe('gestaltsDiscoveryQueue', () => {
       nodeGraph,
       // @ts-ignore: TLS not needed for this test
       tlsConfig: {},
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -1393,7 +1398,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
   let nodeGraph: NodeGraph;
   let sigchain: Sigchain;
   let nodeManager: NodeManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let discovery: Discovery;
   let testProvider: TestProvider;
   const connectedIdentity = 'trusted-node' as IdentityId;
@@ -1455,6 +1460,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       nodeGraph,
       // @ts-ignore: TLS not needed for this test
       tlsConfig: {},
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -1747,7 +1753,7 @@ describe('gestaltsGestaltTrustByNode', () => {
   let nodeGraph: NodeGraph;
   let sigchain: Sigchain;
   let nodeManager: NodeManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let discovery: Discovery;
   let testProvider: TestProvider;
   const connectedIdentity = 'trusted-node' as IdentityId;
@@ -1875,6 +1881,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       nodeGraph,
       // @ts-ignore: TLS not needed for this test
       tlsConfig: {},
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,

--- a/tests/client/handlers/nodes.test.ts
+++ b/tests/client/handlers/nodes.test.ts
@@ -4,6 +4,7 @@ import type { TLSConfig, Host, Port } from '#network/types.js';
 import type { Notification } from '#notifications/types.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
 import type { NodeAddress, NodeContactAddressData } from '#nodes/types.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -44,6 +45,7 @@ import * as networkUtils from '#network/utils.js';
 import * as notificationsUtils from '#notifications/utils.js';
 import * as validationErrors from '#validation/errors.js';
 import { parseNodeId } from '#ids/index.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('nodesAdd', () => {
   const logger = new Logger('nodesAdd test', LogLevel.WARN, [
@@ -64,7 +66,7 @@ describe('nodesAdd', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let sigchain: Sigchain;
   beforeEach(async () => {
@@ -105,6 +107,7 @@ describe('nodesAdd', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -266,7 +269,7 @@ describe('nodesClaim', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -336,6 +339,7 @@ describe('nodesClaim', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -454,7 +458,7 @@ describe('nodesFind', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let sigchain: Sigchain;
   let mockedFindNode: jest.SpiedFunction<typeof NodeManager.prototype.findNode>;
@@ -507,6 +511,7 @@ describe('nodesFind', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -610,7 +615,7 @@ describe('nodesPing', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let sigchain: Sigchain;
   let mockedPingNode: jest.SpiedFunction<typeof NodeManager.prototype.pingNode>;
@@ -653,6 +658,7 @@ describe('nodesPing', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -766,7 +772,7 @@ describe('nodesGetAll', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let sigchain: Sigchain;
   beforeEach(async () => {
@@ -807,6 +813,7 @@ describe('nodesGetAll', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -914,7 +921,7 @@ describe('nodesListConnections', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let sigchain: Sigchain;
   let mockedConnection: jest.SpiedFunction<
@@ -962,6 +969,7 @@ describe('nodesListConnections', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,

--- a/tests/client/handlers/notifications.test.ts
+++ b/tests/client/handlers/notifications.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '#ids/types.js';
 import type { VaultName } from '#vaults/types.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -53,6 +54,7 @@ import * as nodesUtils from '#nodes/utils.js';
 import * as keysUtils from '#keys/utils/index.js';
 import * as networkUtils from '#network/utils.js';
 import * as notificationsUtils from '#notifications/utils.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 async function* arrayToGenerator<T>(
   array: Array<T>,
@@ -81,7 +83,7 @@ describe('notificationsInboxClear', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -134,6 +136,7 @@ describe('notificationsInboxClear', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -250,7 +253,7 @@ describe('notificationsInboxRead', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -304,6 +307,7 @@ describe('notificationsInboxRead', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -678,7 +682,7 @@ describe('notificationsInboxRemove', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -731,6 +735,7 @@ describe('notificationsInboxRemove', () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -853,7 +858,7 @@ describe('notificationsOutboxClear', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -906,6 +911,7 @@ describe('notificationsOutboxClear', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -1022,7 +1028,7 @@ describe('notificationsOutboxRead', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -1076,6 +1082,7 @@ describe('notificationsOutboxRead', () => {
       keyRing,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -1380,7 +1387,7 @@ describe('notificationsOutboxRemove', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -1433,6 +1440,7 @@ describe('notificationsOutboxRemove', () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,
@@ -1555,7 +1563,7 @@ describe('notificationsSend', () => {
   }>;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let acl: ACL;
@@ -1605,6 +1613,7 @@ describe('notificationsSend', () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       tlsConfig: {} as TLSConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -4,6 +4,7 @@ import type { NodeId } from '#ids/index.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
 import type { DiscoveryQueueInfo } from '#discovery/types.js';
 import type { ClaimLinkIdentity } from '#claims/payloads/claimLinkIdentity.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -36,6 +37,7 @@ import * as keysUtils from '#keys/utils/index.js';
 import * as gestaltsUtils from '#gestalts/utils.js';
 import { encodeProviderIdentityId } from '#ids/index.js';
 import { polykeyWorkerManifest } from '#workers/index.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('Discovery', () => {
   const password = 'password';
@@ -58,7 +60,7 @@ describe('Discovery', () => {
   let identitiesManager: IdentitiesManager;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let db: DB;
   let acl: ACL;
@@ -152,6 +154,7 @@ describe('Discovery', () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       tlsConfig,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,
       connectionIdleTimeoutTimeScale: 0,

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -36,12 +36,12 @@ describe(`${NodeConnection.name}`, () => {
   let rpcServer: RPCServer;
   let clientSocket: QUICSocket;
 
-  const nodeConnections: Array<NodeConnection> = [];
+  const nodeConnections: Array<NodeConnection<AgentClientManifest>> = [];
   /**
    * Adds created nodeConnections to the `nodeConnections` array for automated cleanup.
    * @param nc
    */
-  const extractNodeConnection = (nc: NodeConnection) => {
+  const extractNodeConnection = (nc: NodeConnection<AgentClientManifest>) => {
     nodeConnections.push(nc);
     return nc;
   };
@@ -328,7 +328,8 @@ describe(`${NodeConnection.name}`, () => {
     await destroyP;
   });
   test('should wrap reverse connection', async () => {
-    const nodeConnectionReverseProm = promise<NodeConnection>();
+    const nodeConnectionReverseProm =
+      promise<NodeConnection<AgentClientManifest>>();
     quicServer.removeEventListener(
       quicEvents.EventQUICConnectionStream.name,
       handleEventQUICConnectionStream,
@@ -370,7 +371,8 @@ describe(`${NodeConnection.name}`, () => {
     await destroyP;
   });
   test('should handle reverse streams', async () => {
-    const nodeConnectionReverseProm = promise<NodeConnection>();
+    const nodeConnectionReverseProm =
+      promise<NodeConnection<AgentClientManifest>>();
     const reverseStreamProm = promise<RPCStream<Uint8Array, Uint8Array>>();
     quicServer.removeEventListener(
       quicEvents.EventQUICConnectionStream.name,

--- a/tests/nodes/NodeConnectionManager.test.ts
+++ b/tests/nodes/NodeConnectionManager.test.ts
@@ -11,11 +11,12 @@ import type {
   SuccessMessage,
 } from '#nodes/agent/types.js';
 import type { ContextTimed } from '@matrixai/contexts';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import { jest } from '@jest/globals';
 import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
 import { Timer } from '@matrixai/timer';
 import { destroyed } from '@matrixai/async-init';
-import { UnaryHandler } from '@matrixai/rpc';
+import { UnaryCaller, UnaryHandler } from '@matrixai/rpc';
 import * as nodesTestUtils from './utils.js';
 import * as keysTestUtils from '../keys/utils.js';
 import * as testsUtils from '../utils/index.js';
@@ -28,6 +29,9 @@ import NodesConnectionSignalFinal from '#nodes/agent/handlers/NodesConnectionSig
 import NodesConnectionSignalInitial from '#nodes/agent/handlers/NodesConnectionSignalInitial.js';
 import * as utils from '#utils/index.js';
 import * as nodesUtils from '#nodes/utils.js';
+import rpcClientManifest, {
+  manifestClientCore,
+} from '#nodes/agent/callers/index.js';
 
 class DummyNodesAuthenticateConnection extends UnaryHandler<
   ObjectEmpty,
@@ -73,6 +77,7 @@ describe(`${NodeConnectionManager.name}`, () => {
       keyRing: dummyKeyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       tlsConfig: tlsConfig,
+      rpcClientManifest: rpcClientManifest,
     });
     await nodeConnectionManager.start({
       agentService: dummyManifest,
@@ -93,6 +98,7 @@ describe(`${NodeConnectionManager.name}`, () => {
       keyRing: dummyKeyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       tlsConfig: tlsConfig,
+      rpcClientManifest: rpcClientManifest,
     });
     await nodeConnectionManager.start({
       agentService: {} as AgentServerManifest,
@@ -103,6 +109,33 @@ describe(`${NodeConnectionManager.name}`, () => {
       agentService: {} as AgentServerManifest,
       host: localHost as Host,
     });
+    await nodeConnectionManager.stop();
+  });
+  test('NodeConnectionManager with custom client manifest', async () => {
+    const keyPair = keysUtils.generateKeyPair();
+    const nodeId = keysUtils.publicKeyToNodeId(keyPair.publicKey);
+    const tlsConfig = await testsUtils.createTLSConfig(keyPair);
+    const dummyKeyRing = {
+      getNodeId: () => nodeId,
+      keyPair,
+    } as KeyRing;
+
+    const newManifest = {
+      ...manifestClientCore,
+      echo: new UnaryCaller<{ message: string }, { response: string }>(),
+    };
+
+    const nodeConnectionManager = new NodeConnectionManager({
+      keyRing: dummyKeyRing,
+      logger: logger.getChild(NodeConnectionManager.name),
+      tlsConfig: tlsConfig,
+      rpcClientManifest: newManifest,
+    });
+    await nodeConnectionManager.start({
+      agentService: dummyManifest,
+      host: localHost,
+    });
+
     await nodeConnectionManager.stop();
   });
 
@@ -1392,7 +1425,9 @@ describe(`${NodeConnectionManager.name}`, () => {
       await ncmPeer1.nodeConnectionManager.isAuthenticatedP(ncmPeer2.nodeId);
       // Excessive connections will fail due to rate limit
       const connectionsP = (async () => {
-        const connectionPs: Array<Promise<NodeConnection>> = [];
+        const connectionPs: Array<
+          Promise<NodeConnection<AgentClientManifest>>
+        > = [];
         for (let i = 0; i < 21; i++) {
           const connectionP =
             ncmLocal.nodeConnectionManager.createConnectionPunch(

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '#nodes/agent/types.js';
 import type { JSONValue, ObjectEmpty } from '#index.js';
 import type { ContextTimed } from '@matrixai/contexts';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -46,6 +47,7 @@ import { Sigchain } from '#sigchain/index.js';
 import { KeyRing } from '#keys/index.js';
 import NodeConnectionQueue from '#nodes/NodeConnectionQueue.js';
 import * as utils from '#utils/index.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 class DummyNodesAuthenticateConnection extends UnaryHandler<
   ObjectEmpty,
@@ -116,7 +118,7 @@ describe(`${NodeManager.name}`, () => {
         nodeConnectionManager: {
           addEventListener: (..._args) => {},
           removeEventListener: (..._args) => {},
-        } as NodeConnectionManager,
+        } as NodeConnectionManager<AgentClientManifest>,
         nodeGraph: {} as nodeGraph,
         sigchain: {} as Sigchain,
         taskManager,
@@ -154,7 +156,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchain: Sigchain;
     let gestaltGraph: GestaltGraph;
     let nodeGraph: NodeGraph;
-    let nodeConnectionManager: NodeConnectionManager;
+    let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     let taskManager: TaskManager;
     let nodeManager: NodeManager;
 
@@ -196,6 +198,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig: await testsUtils.createTLSConfig(keyRing.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,
@@ -431,7 +434,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchain: Sigchain;
     let gestaltGraph: GestaltGraph;
     let nodeGraph: NodeGraph;
-    let nodeConnectionManager: NodeConnectionManager;
+    let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     let taskManager: TaskManager;
     let nodeManager: NodeManager;
 
@@ -442,7 +445,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchainPeer: Sigchain;
     let gestaltGraphPeer: GestaltGraph;
     let nodeGraphPeer: NodeGraph;
-    let nodeConnectionManagerPeer: NodeConnectionManager;
+    let nodeConnectionManagerPeer: NodeConnectionManager<AgentClientManifest>;
     let taskManagerPeer: TaskManager;
     let nodeManagerPeer: NodeManager;
 
@@ -484,6 +487,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig: await testsUtils.createTLSConfig(keyRing.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,
@@ -556,6 +560,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManagerPeer = new NodeConnectionManager({
         keyRing: keyRingPeer,
         tlsConfig: await testsUtils.createTLSConfig(keyRingPeer.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,
@@ -944,7 +949,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchain: Sigchain;
     let gestaltGraph: GestaltGraph;
     let nodeGraph: NodeGraph;
-    let nodeConnectionManager: NodeConnectionManager;
+    let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     let taskManager: TaskManager;
     let nodeManager: NodeManager;
 
@@ -955,7 +960,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchainPeer: Sigchain;
     let gestaltGraphPeer: GestaltGraph;
     let nodeGraphPeer: NodeGraph;
-    let nodeConnectionManagerPeer: NodeConnectionManager;
+    let nodeConnectionManagerPeer: NodeConnectionManager<AgentClientManifest>;
     let taskManagerPeer: TaskManager;
     let nodeManagerPeer: NodeManager;
 
@@ -997,6 +1002,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig: await testsUtils.createTLSConfig(keyRing.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,
@@ -1070,6 +1076,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManagerPeer = new NodeConnectionManager({
         keyRing: keyRingPeer,
         tlsConfig: await testsUtils.createTLSConfig(keyRingPeer.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,
@@ -1170,7 +1177,7 @@ describe(`${NodeManager.name}`, () => {
     let sigchain: Sigchain;
     let gestaltGraph: GestaltGraph;
     let nodeGraph: NodeGraph;
-    let nodeConnectionManager: NodeConnectionManager;
+    let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     let taskManager: TaskManager;
     let nodeManager: NodeManager;
 
@@ -1265,6 +1272,7 @@ describe(`${NodeManager.name}`, () => {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig: await testsUtils.createTLSConfig(keyRing.keyPair),
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,

--- a/tests/nodes/agent/handlers/nodesAuditsGet.test.ts
+++ b/tests/nodes/agent/handlers/nodesAuditsGet.test.ts
@@ -1,6 +1,7 @@
 import type { AuditEventId } from '#ids/index.js';
 import type NodeConnectionManager from '#nodes/NodeConnectionManager.js';
 import type Discovery from '#discovery/Discovery.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -65,7 +66,8 @@ describe('nodesAuditEventsGet', () => {
     });
     audit = await Audit.createAudit({
       db,
-      nodeConnectionManager: new EventTarget() as NodeConnectionManager,
+      nodeConnectionManager:
+        new EventTarget() as NodeConnectionManager<AgentClientManifest>,
       discovery: new EventTarget() as Discovery,
       logger,
     });

--- a/tests/nodes/agent/handlers/nodesClaimNetworkVerify.test.ts
+++ b/tests/nodes/agent/handlers/nodesClaimNetworkVerify.test.ts
@@ -4,6 +4,7 @@ import type { KeyPair } from '#keys/types.js';
 import type { SignedTokenEncoded } from '#tokens/types.js';
 import type { ClaimNetworkAuthority } from '#claims/payloads/claimNetworkAuthority.js';
 import type { ClaimNetworkAccess } from '#claims/payloads/claimNetworkAccess.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -109,7 +110,7 @@ describe('nodesClaimNetworkVerify', () => {
       db,
       keyRing,
       gestaltGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: {} as NodeConnectionManager<AgentClientManifest>,
       nodeGraph: {} as NodeGraph,
       sigchain,
       taskManager,

--- a/tests/nodes/agent/handlers/nodesClosestActiveConnectionsGet.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestActiveConnectionsGet.test.ts
@@ -5,6 +5,7 @@ import type { NodeId, NodeIdString } from '#ids/index.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
 import type { NodeConnection } from '#nodes/index.js';
 import type { ActiveConnectionDataMessage } from '#nodes/agent/types.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import * as testsUtils from '../../../utils/index.js';
 import * as keysUtils from '#keys/utils/index.js';
@@ -12,6 +13,7 @@ import NodeConnectionManager from '#nodes/NodeConnectionManager.js';
 import NodesAuthenticateConnection from '#nodes/agent/handlers/NodesAuthenticateConnection.js';
 import NodesClosestActiveConnectionsGet from '#nodes/agent/handlers/NodesClosestActiveConnectionsGet.js';
 import * as nodesUtils from '#nodes/utils.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('nodesClosestLocalNode', () => {
   const logger = new Logger('nodesClosestLocalNode test', LogLevel.WARN, [
@@ -22,11 +24,11 @@ describe('nodesClosestLocalNode', () => {
 
   let nodeIdLocal: NodeId;
   let keyRingDummyLocal: KeyRing;
-  let nodeConnectionManagerLocal: NodeConnectionManager;
+  let nodeConnectionManagerLocal: NodeConnectionManager<AgentClientManifest>;
 
   let nodeIdPeer1: NodeId;
   let keyRingDummyPeer1: KeyRing;
-  let nodeConnectionManagerPeer1: NodeConnectionManager;
+  let nodeConnectionManagerPeer1: NodeConnectionManager<AgentClientManifest>;
   let portPeer1: Port;
 
   beforeEach(async () => {
@@ -41,6 +43,7 @@ describe('nodesClosestLocalNode', () => {
       keyRing: keyRingDummyLocal,
       logger: logger.getChild(`${NodeConnectionManager.name}Local`),
       tlsConfig: tlsConfigLocal,
+      rpcClientManifest: rpcClientManifest,
       connectionIdleTimeoutTimeMin: 1000,
       connectionIdleTimeoutTimeScale: 0,
       connectionConnectTimeoutTime: timeoutTime,
@@ -65,6 +68,7 @@ describe('nodesClosestLocalNode', () => {
       keyRing: keyRingDummyPeer1,
       logger: logger.getChild(`${NodeConnectionManager.name}Peer1`),
       tlsConfig: tlsConfigPeer1,
+      rpcClientManifest: rpcClientManifest,
       connectionConnectTimeoutTime: timeoutTime,
       authenticateNetworkForwardCallback:
         nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
@@ -123,7 +127,7 @@ describe('nodesClosestLocalNode', () => {
         connections: Record<
           string,
           {
-            connection: NodeConnection;
+            connection: NodeConnection<AgentClientManifest>;
             timer: Timer | null;
             usageCount: number;
           }
@@ -152,7 +156,7 @@ describe('nodesClosestLocalNode', () => {
               host: localHost,
               port: i,
               destroy: () => {},
-            } as NodeConnection,
+            } as NodeConnection<AgentClientManifest>,
             timer: null,
             usageCount: 0,
           },

--- a/tests/nodes/agent/handlers/nodesCrossSignClaim.test.ts
+++ b/tests/nodes/agent/handlers/nodesCrossSignClaim.test.ts
@@ -3,6 +3,7 @@ import type { AgentClaimMessage } from '#nodes/agent/types.js';
 import type { NodeId } from '#ids/index.js';
 import type { ClaimLinkNode } from '#claims/payloads/index.js';
 import type { KeyPair } from '#keys/types.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -104,7 +105,7 @@ describe('nodesCrossSignClaim', () => {
       db,
       keyRing,
       gestaltGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: {} as NodeConnectionManager<AgentClientManifest>,
       nodeGraph: {} as NodeGraph,
       sigchain,
       taskManager,

--- a/tests/nodes/agent/handlers/notificationsSend.test.ts
+++ b/tests/nodes/agent/handlers/notificationsSend.test.ts
@@ -3,6 +3,7 @@ import type { NodeId } from '#ids/index.js';
 import type GestaltGraph from '#gestalts/GestaltGraph.js';
 import type { Host } from '#network/types.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -16,7 +17,9 @@ import KeyRing from '#keys/KeyRing.js';
 import * as nodesUtils from '#nodes/utils.js';
 import NodeGraph from '#nodes/NodeGraph.js';
 import * as notificationsUtils from '#notifications/utils.js';
-import { notificationsSend } from '#nodes/agent/callers/index.js';
+import rpcClientManifest, {
+  notificationsSend,
+} from '#nodes/agent/callers/index.js';
 import NotificationsSend from '#nodes/agent/handlers/NotificationsSend.js';
 import NotificationsManager from '#notifications/NotificationsManager.js';
 import NodeConnectionManager from '#nodes/NodeConnectionManager.js';
@@ -45,7 +48,7 @@ describe('notificationsSend', () => {
   let acl: ACL;
   let sigchain: Sigchain;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let notificationsManager: NotificationsManager;
   let rpcServer: RPCServer;
@@ -121,6 +124,7 @@ describe('notificationsSend', () => {
     );
     nodeConnectionManager = new NodeConnectionManager({
       tlsConfig: tlsConfigClient,
+      rpcClientManifest: rpcClientManifest,
       keyRing,
       connectionConnectTimeoutTime: 2000,
       connectionIdleTimeoutTimeMin: 2000,

--- a/tests/nodes/utils.ts
+++ b/tests/nodes/utils.ts
@@ -9,6 +9,7 @@ import type Logger from '@matrixai/logger';
 import type { KeyRing } from '#keys/index.js';
 import type { Host, Port } from '#network/types.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import { webcrypto } from 'crypto';
 import { IdInternal } from '@matrixai/id';
 import * as fc from 'fast-check';
@@ -18,6 +19,7 @@ import * as keysUtils from '#keys/utils/index.js';
 import * as utils from '#utils/index.js';
 import * as nodesUtils from '#nodes/utils.js';
 import NodeConnectionManager from '#nodes/NodeConnectionManager.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 /**
  * Generate random `NodeId`
@@ -262,7 +264,7 @@ function createReasonConverters() {
 
 type NCMState = {
   nodeId: NodeId;
-  nodeConnectionManager: NodeConnectionManager;
+  nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   port: Port;
 };
 
@@ -309,6 +311,7 @@ async function nodeConnectionManagerFactory({
     keyRing: keyRing,
     logger: logger,
     tlsConfig: tlsConfig,
+    rpcClientManifest: rpcClientManifest,
     connectionFindConcurrencyLimit,
     connectionFindLocalTimeoutTime,
     connectionIdleTimeoutTimeMin,

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -8,6 +8,7 @@ import type { VaultActions, VaultName } from '#vaults/types.js';
 import type { Notification, NotificationData } from '#notifications/types.js';
 import type GestaltGraph from '#gestalts/GestaltGraph.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -35,6 +36,7 @@ import * as vaultsUtils from '#vaults/utils.js';
 import * as nodesUtils from '#nodes/utils.js';
 import * as keysUtils from '#keys/utils/index.js';
 import { polykeyWorkerManifest } from '#workers/index.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('NotificationsManager', () => {
   const password = 'password';
@@ -59,7 +61,7 @@ describe('NotificationsManager', () => {
   let db: DB;
   let nodeGraph: NodeGraph;
   let taskManager: TaskManager;
-  let nodeConnectionManager: NodeConnectionManager;
+  let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
   let nodeManager: NodeManager;
   let keyRing: KeyRing;
   let sigchain: Sigchain;
@@ -110,6 +112,7 @@ describe('NotificationsManager', () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       tlsConfig,
+      rpcClientManifest: rpcClientManifest,
       authenticateNetworkForwardCallback:
         nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
           testsUtils.testNetworkName,

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -10,6 +10,7 @@ import type NotificationsManager from '#notifications/NotificationsManager.js';
 import type { Host } from '#network/types.js';
 import type { Sigchain } from '#sigchain/index.js';
 import type { AgentServerManifest } from '#nodes/agent/handlers/index.js';
+import type { AgentClientManifest } from '#nodes/agent/callers/index.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -40,6 +41,7 @@ import * as keysUtils from '#keys/utils/index.js';
 import * as vaultsErrors from '#vaults/errors.js';
 import * as vaultsUtils from '#vaults/utils.js';
 import * as nodesUtils from '#nodes/utils.js';
+import rpcClientManifest from '#nodes/agent/callers/index.js';
 
 describe('VaultManager', () => {
   const localhost = '127.0.0.1';
@@ -596,7 +598,7 @@ describe('VaultManager', () => {
     let allDataDir: string;
     let keyRing: KeyRing;
     let nodeGraph: NodeGraph;
-    let nodeConnectionManager: NodeConnectionManager;
+    let nodeConnectionManager: NodeConnectionManager<AgentClientManifest>;
     let nodeManager: NodeManager;
     let remoteKeynode1: PolykeyAgent, remoteKeynode2: PolykeyAgent;
     let localNodeId: NodeId;
@@ -710,6 +712,7 @@ describe('VaultManager', () => {
       nodeConnectionManager = new NodeConnectionManager({
         keyRing,
         tlsConfig,
+        rpcClientManifest: rpcClientManifest,
         authenticateNetworkForwardCallback:
           nodesUtils.nodesAuthenticateConnectionForwardBasicPublicFactory(
             testsUtils.testNetworkName,


### PR DESCRIPTION



### Description

This allows us to override what methods are callable on connections. It should allow us to tailor our agent-agent communication between PKE and PK. So a PKE agent can provide different functionality to a normal PK agent. This allows us to have different RPC endpoints for 

### Issues Fixed

* Related: https://github.com/MatrixAI/Polykey-Enterprise/issues/188
* REF ENG-614

### Tasks
- [x] 1. update the `NodeConnectionManager` to have the `clientManifest` passed in.
- [x] 2. Create a test showcasing how to use a custom `clientManifest`.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
