### PR TITLE
Added token verification and signing for login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dist
 # editor
 .vscode/
 .idea/
+.prettierrc

--- a/src/client/callers/authSignToken.ts
+++ b/src/client/callers/authSignToken.ts
@@ -1,0 +1,12 @@
+import type { HandlerTypes } from '@matrixai/rpc';
+import type AuthSignToken from '../handlers/AgentLockAll.js';
+import { UnaryCaller } from '@matrixai/rpc';
+
+type CallerTypes = HandlerTypes<AuthSignToken>;
+
+const authSignToken = new UnaryCaller<
+  CallerTypes['input'],
+  CallerTypes['output']
+>();
+
+export default authSignToken;

--- a/src/client/callers/authSignToken.ts
+++ b/src/client/callers/authSignToken.ts
@@ -1,5 +1,5 @@
 import type { HandlerTypes } from '@matrixai/rpc';
-import type AuthSignToken from '../handlers/AgentLockAll.js';
+import type AuthSignToken from '../handlers/AuthSignToken.js';
 import { UnaryCaller } from '@matrixai/rpc';
 
 type CallerTypes = HandlerTypes<AuthSignToken>;

--- a/src/client/callers/index.ts
+++ b/src/client/callers/index.ts
@@ -4,6 +4,7 @@ import agentStop from './agentStop.js';
 import agentUnlock from './agentUnlock.js';
 import auditEventsGet from './auditEventsGet.js';
 import auditMetricGet from './auditMetricGet.js';
+import authSignToken from './authSignToken.js';
 import gestaltsActionsGetByIdentity from './gestaltsActionsGetByIdentity.js';
 import gestaltsActionsGetByNode from './gestaltsActionsGetByNode.js';
 import gestaltsActionsSetByIdentity from './gestaltsActionsSetByIdentity.js';
@@ -85,6 +86,7 @@ const clientManifest = {
   agentUnlock,
   auditEventsGet,
   auditMetricGet,
+  authSignToken,
   gestaltsActionsGetByIdentity,
   gestaltsActionsGetByNode,
   gestaltsActionsSetByIdentity,
@@ -165,6 +167,7 @@ export {
   agentStop,
   agentUnlock,
   auditEventsGet,
+  authSignToken,
   gestaltsActionsGetByIdentity,
   gestaltsActionsGetByNode,
   gestaltsActionsSetByIdentity,

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -53,7 +53,7 @@ class ErrorClientVerificationFailed<T> extends ErrorClientService<T> {
 class ErrorAuthentication<T> extends ErrorPolykey<T> {}
 
 class ErrorAuthenticationInvalidToken<T> extends ErrorAuthentication<T> {
-  static description = 'Incoming token does not match its signature';
+  static description = 'Token is invalid';
   exitCode = sysexits.PROTOCOL;
 }
 

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -50,6 +50,13 @@ class ErrorClientVerificationFailed<T> extends ErrorClientService<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorAuthentication<T> extends ErrorPolykey<T> {}
+
+class ErrorAuthenticationInvalidToken<T> extends ErrorAuthentication<T> {
+  static description = 'Incoming token does not match its signature';
+  exitCode = sysexits.PROTOCOL;
+}
+
 export {
   ErrorClient,
   ErrorClientAuthMissing,
@@ -62,4 +69,6 @@ export {
   ErrorClientServiceNotRunning,
   ErrorClientServiceDestroyed,
   ErrorClientVerificationFailed,
+  ErrorAuthentication,
+  ErrorAuthenticationInvalidToken,
 };

--- a/src/client/handlers/AuthSignToken.ts
+++ b/src/client/handlers/AuthSignToken.ts
@@ -28,11 +28,19 @@ class AuthSignToken extends UnaryHandler<
     // Get and verify incoming node
     const inputToken = { payload: input.payload, signatures: input.signatures };
     const incomingToken = Token.fromEncoded<IdentityRequestData>(inputToken);
+    if (!('publicKey' in incomingToken.payload)) {
+      throw new clientErrors.ErrorAuthenticationInvalidToken(
+        'Input token does not contain public key',
+      );
+    }
     const incomingPublicKey = Buffer.from(
       incomingToken.payload.publicKey,
+      'base64url',
     ) as PublicKey;
     if (!incomingToken.verifyWithPublicKey(incomingPublicKey)) {
-      throw new clientErrors.ErrorAuthenticationInvalidToken();
+      throw new clientErrors.ErrorAuthenticationInvalidToken(
+        'Incoming token does not match its signature',
+      );
     }
 
     // Create the outgoing token with the incoming token integrated into the

--- a/src/client/handlers/AuthSignToken.ts
+++ b/src/client/handlers/AuthSignToken.ts
@@ -1,0 +1,51 @@
+import type {
+  ClientRPCRequestParams,
+  ClientRPCResponseResult,
+  IdentityRequestData,
+  IdentityResponseData,
+  TokenIdentityRequest,
+  TokenIdentityResponse,
+} from '../types.js';
+import type KeyRing from '../../keys/KeyRing.js';
+import type { PublicKey } from '../../keys/types.js';
+import { UnaryHandler } from '@matrixai/rpc';
+import Token from '../../tokens/Token.js';
+import * as clientErrors from '../errors.js';
+import * as nodesUtils from '../../nodes/utils.js';
+
+class AuthSignToken extends UnaryHandler<
+  {
+    keyRing: KeyRing;
+  },
+  ClientRPCRequestParams<TokenIdentityRequest>,
+  ClientRPCResponseResult<TokenIdentityResponse>
+> {
+  public handle = async (
+    input: ClientRPCRequestParams<TokenIdentityRequest>,
+  ): Promise<TokenIdentityResponse> => {
+    const { keyRing }: { keyRing: KeyRing } = this.container;
+
+    // Get and verify incoming node
+    const inputToken = { payload: input.payload, signatures: input.signatures };
+    const incomingToken = Token.fromEncoded<IdentityRequestData>(inputToken);
+    const incomingPublicKey = Buffer.from(
+      incomingToken.payload.publicKey,
+    ) as PublicKey;
+    if (!incomingToken.verifyWithPublicKey(incomingPublicKey)) {
+      throw new clientErrors.ErrorAuthenticationInvalidToken();
+    }
+
+    // Create the outgoing token with the incoming token integrated into the
+    // payload.
+    const outgoingTokenPayload: IdentityResponseData = {
+      requestToken: inputToken,
+      nodeId: nodesUtils.encodeNodeId(keyRing.getNodeId()),
+    };
+    const outgoingToken =
+      Token.fromPayload<IdentityResponseData>(outgoingTokenPayload);
+    outgoingToken.signWithPrivateKey(keyRing.keyPair);
+    return outgoingToken.toEncoded();
+  };
+}
+
+export default AuthSignToken;

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -22,6 +22,7 @@ import AgentStop from './AgentStop.js';
 import AgentUnlock from './AgentUnlock.js';
 import AuditEventsGet from './AuditEventsGet.js';
 import AuditMetricGet from './AuditMetricGet.js';
+import AuthSignToken from './AuthSignToken.js';
 import GestaltsActionsGetByIdentity from './GestaltsActionsGetByIdentity.js';
 import GestaltsActionsGetByNode from './GestaltsActionsGetByNode.js';
 import GestaltsActionsSetByIdentity from './GestaltsActionsSetByIdentity.js';
@@ -122,6 +123,7 @@ const serverManifest = (container: {
     agentUnlock: new AgentUnlock(container),
     auditEventsGet: new AuditEventsGet(container),
     auditMetricGet: new AuditMetricGet(container),
+    authSignToken: new AuthSignToken(container),
     gestaltsActionsGetByIdentity: new GestaltsActionsGetByIdentity(container),
     gestaltsActionsGetByNode: new GestaltsActionsGetByNode(container),
     gestaltsActionsSetByIdentity: new GestaltsActionsSetByIdentity(container),
@@ -208,6 +210,7 @@ export {
   AgentUnlock,
   AuditEventsGet,
   AuditMetricGet,
+  AuthSignToken,
   GestaltsActionsGetByIdentity,
   GestaltsActionsGetByNode,
   GestaltsActionsSetByIdentity,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -21,6 +21,7 @@ import type {
 } from '../keys/types.js';
 import type { Notification } from '../notifications/types.js';
 import type { ProviderToken } from '../identities/types.js';
+import type { TokenPayload, SignedTokenEncoded } from '../tokens/types.js';
 import type { AuditMetricGetTypeOverride } from './callers/auditMetricGet.js';
 import type {
   NodeContact,
@@ -106,6 +107,22 @@ type ClaimNodeMessage = NodeIdMessage & {
 type TokenMessage = {
   token: ProviderToken;
 };
+
+// Return URL must be present on the token, otherwise token contents is decided
+// by the client.
+type IdentityRequestData = TokenPayload & {
+  returnUrl: string;
+  publicKey: string;
+};
+
+type TokenIdentityRequest = SignedTokenEncoded;
+
+type IdentityResponseData = TokenPayload & {
+  requestToken: TokenIdentityRequest;
+  nodeId: NodeIdEncoded;
+};
+
+type TokenIdentityResponse = SignedTokenEncoded;
 
 // Nodes messages
 
@@ -405,6 +422,10 @@ export type {
   ClaimIdMessage,
   ClaimNodeMessage,
   TokenMessage,
+  IdentityRequestData,
+  IdentityResponseData,
+  TokenIdentityRequest,
+  TokenIdentityResponse,
   NodeIdMessage,
   AddressMessage,
   NodeAddressMessage,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -111,7 +111,7 @@ type TokenMessage = {
 // Return URL must be present on the token, otherwise token contents is decided
 // by the client.
 type IdentityRequestData = TokenPayload & {
-  returnUrl: string;
+  returnURL: string;
   publicKey: string;
 };
 

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -477,7 +477,10 @@ function fromError(error: any) {
     // serialising only the error type, message and its stack.
     const wrappedError = new errors.ErrorPolykeyUnexpected(
       `Unexpected error occurred: ${error.name}`,
-      { cause: error },
+      {
+        cause: error,
+        data: { message: 'message' in error ? error.message : undefined },
+      },
     );
     return wrappedError.toJSON();
   }


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR implements a protocol for taking in a signed JWT, verifying it, then adding additional data and returning the data alongside the original token back to the caller.

This is used in a protocol to securely provide identity proof to a platform. This is not used to access any protected resources like granting RPC access.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Addresses https://github.com/MatrixAI/Polykey-CLI/issues/408

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Create `AuthSignToken` RPC methods
- [ ] 2. Add tests confirming this behaviour

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
